### PR TITLE
Kernel 6.12 compile fix

### DIFF
--- a/packages/winesync/winesync.c-9ac10c6e711ec096274ecc676ae83a7cf2a1213f
+++ b/packages/winesync/winesync.c-9ac10c6e711ec096274ecc676ae83a7cf2a1213f
@@ -4,7 +4,8 @@
  *
  * Copyright (C) 2021 Zebediah Figura
  */
-
+ 
+#include <linux/version.h>
 #include <linux/fs.h>
 #include <linux/miscdevice.h>
 #include <linux/module.h>
@@ -1184,7 +1185,9 @@ static const struct file_operations winesync_fops = {
 	.release	= winesync_char_release,
 	.unlocked_ioctl	= winesync_char_ioctl,
 	.compat_ioctl	= winesync_char_ioctl,
-	.llseek		= no_llseek,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+        .llseek = no_llseek,
+#endif
 };
 
 static struct miscdevice winesync_misc = {


### PR DESCRIPTION
Fix compile for Linux 6.12, I tested it and it seems to work.
```
Linux auros 6.12.0-rc3-1-cachyos-rc #1 SMP PREEMPT_DYNAMIC Fri, 18 Oct 2024 07:31:17 +0000 x86_64 GNU/Linu
wine: using fast synchronization.
```