### PR TITLE
kernel-618: guard PMD_SHIFT usage in TTM prefault macro

### DIFF
--- a/kernel-raptorlake-experiments/618/ttm_bo.h
+++ b/kernel-raptorlake-experiments/618/ttm_bo.h
@@ -52,7 +52,8 @@
  * Benchmarks show this improves 1GB buffer mapping by 4-10x compared to
  * single-page faulting.
  */
-#if defined(CONFIG_PGTABLE_LEVELS) && (CONFIG_PGTABLE_LEVELS > 2)
+#if defined(CONFIG_PGTABLE_LEVELS) && (CONFIG_PGTABLE_LEVELS > 2) && \
+	defined(PMD_SHIFT)
 #define TTM_BO_VM_NUM_PREFAULT	((pgoff_t)1 << (PMD_SHIFT - PAGE_SHIFT))
 #else
 #define TTM_BO_VM_NUM_PREFAULT	((pgoff_t)16)


### PR DESCRIPTION
### Motivation
- Avoid possible compile breakage on architectures/configurations where `CONFIG_PGTABLE_LEVELS > 2` is true but `PMD_SHIFT` is not available in this header context, while preserving the PMD-sized prefault optimization on systems that provide `PMD_SHIFT`.

### Description
- Add an extra preprocessor guard in `kernel-raptorlake-experiments/618/ttm_bo.h` so `TTM_BO_VM_NUM_PREFAULT` uses the PMD-based value only when `PMD_SHIFT` is defined (added `&& defined(PMD_SHIFT)` to the `#if`).

### Testing
- Verified the change with local repository checks (`git diff` output inspected, file contents viewed via `nl`), and committed the update; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698706f03f24832a8f19745795ee2037)