### PR TITLE
aco/optimizer: harden phys-reg check and replace unsafe memmove copy

### DIFF
--- a/vega-experiments/aco_optimizer.cpp
+++ b/vega-experiments/aco_optimizer.cpp
@@ -255,6 +255,8 @@ struct ssa_info {
          return false;
       if (phys_reg != exec && phys_reg != exec_hi)
          return true;
+      if (UNLIKELY(!parent_instr))
+         return false;
       return exec_id == parent_instr->pass_flags;
    }
 };
@@ -314,16 +316,10 @@ struct alu_opt_op {
    };
    uint32_t dpp_ctrl = 0;
 
-   alu_opt_op& operator=(const alu_opt_op& other)
-   {
-      memmove((void*)this, &other, sizeof(*this));
-
-      return *this;
-   }
-
    alu_opt_op() = default;
    alu_opt_op(Operand _op) : op(_op) {};
-   alu_opt_op(const alu_opt_op& other) { *this = other; }
+   alu_opt_op(const alu_opt_op& other) = default;
+   alu_opt_op& operator=(const alu_opt_op& other) = default;
 
    uint64_t constant_after_mods(opt_ctx& ctx, aco_type type) const
    {


### PR DESCRIPTION
### Motivation
- Prevent a potential null-dereference in `ssa_info::is_phys_reg()` when `parent_instr` is unset and eliminate brittle raw-byte copying in `alu_opt_op` that can become UB as the type evolves.

### Description
- Add a defensive null check in `ssa_info::is_phys_reg()` before reading `parent_instr->pass_flags` to avoid dereferencing a null pointer.
- Replace the custom `memmove`-based copy-assignment for `alu_opt_op` with defaulted copy constructor and copy-assignment (`= default`) to use safe, compiler-generated semantics.

### Testing
- Ran a syntax-only compile: `g++ -std=gnu++2a -fsyntax-only -Wall -Wextra -Wpedantic -Ivega-experiments vega-experiments/aco_optimizer.cpp`, which failed due to a missing project header (`aco_builder.h`) in this environment, so full build-time checks could not be completed (test failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a4568500832a956be6ad4fda1dea)