### PR TITLE
aco/optimizer: restore alu_opt_op copy semantics and guard ssa_info::is_phys_reg

### DIFF
--- a/vega-experiments/aco_optimizer.cpp
+++ b/vega-experiments/aco_optimizer.cpp
@@ -255,6 +255,8 @@ struct ssa_info {
          return false;
       if (phys_reg != exec && phys_reg != exec_hi)
          return true;
+      if (UNLIKELY(!parent_instr))
+         return false;
       return exec_id == parent_instr->pass_flags;
    }
 };
@@ -314,16 +316,23 @@ struct alu_opt_op {
    };
    uint32_t dpp_ctrl = 0;
 
-   alu_opt_op& operator=(const alu_opt_op& other)
-   {
-      memmove((void*)this, &other, sizeof(*this));
-
-      return *this;
-   }
-
    alu_opt_op() = default;
    alu_opt_op(Operand _op) : op(_op) {};
-   alu_opt_op(const alu_opt_op& other) { *this = other; }
+
+   alu_opt_op(const alu_opt_op& other)
+       : op(other.op), extract{other.extract[0], other.extract[1]}, _modifiers(other._modifiers),
+         dpp_ctrl(other.dpp_ctrl)
+   {}
+
+   alu_opt_op& operator=(const alu_opt_op& other)
+   {
+      op = other.op;
+      extract[0] = other.extract[0];
+      extract[1] = other.extract[1];
+      _modifiers = other._modifiers;
+      dpp_ctrl = other.dpp_ctrl;
+      return *this;
+   }
 
    uint64_t constant_after_mods(opt_ctx& ctx, aco_type type) const
    {


### PR DESCRIPTION
### Motivation
- Prevent undefined/broken copy/assignment behavior for `alu_opt_op` that made the type non-assignable and triggered compiler errors in container algorithms and `std::swap` usages. 
- Avoid a potential null-dereference when `ssa_info::is_phys_reg()` accessed `parent_instr` without a guard.

### Description
- Implemented an explicit member-wise copy constructor for `alu_opt_op` that copies `op`, both `extract` elements, `_modifiers`, and `dpp_ctrl` via initializer-list semantics.
- Replaced the unsafe `memmove`-based assignment with an explicit copy-assignment that performs member-wise assignments for `op`, `extract`, `_modifiers`, and `dpp_ctrl` and returns `*this`.
- Restored a defensive null check in `ssa_info::is_phys_reg()` to return `false` when `parent_instr` is unset before reading `parent_instr->pass_flags`.

### Testing
- Reproduced the original compiler failures showing template instantiation errors around `std::swap(info.operands[...])` and `small_vec<alu_opt_op>::erase`, which motivated the change (automated build failed).
- Attempted a local syntax-only compile in this environment after the change, but a full compile/syntax check could not be completed because required project headers are not available in the test environment (test could not be run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a4568500832a956be6ad4fda1dea)