### PR TITLE
amdgpu: reduce syncobj waits and TTM mapping overhead in hot paths

### DIFF
--- a/kernel-raptorlake-experiments/618/amdgpu_gem.c
+++ b/kernel-raptorlake-experiments/618/amdgpu_gem.c
@@ -303,9 +303,9 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 	uint32_t *syncobj_handles = NULL;
 	uint32_t __user *user_handles;
 	struct dma_fence *fence;
-	uint32_t recent_handles[4] = { 0U, 0U };
-	uint32_t recent_valid = 0U;
-	uint32_t recent_pos = 0U;
+	uint32_t recent_handles[8] = { 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U };
+	uint8_t recent_valid = 0U;
+	uint32_t last_handle = 0U;
 	uint32_t single_handle;
 	int ret = 0;
 	uint32_t i;
@@ -336,7 +336,7 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 		return ret;
 	}
 
-	if (likely(num_syncobj_handles <= 4U)) {
+	if (likely(num_syncobj_handles <= 8U)) {
 		for (i = 0U; i < num_syncobj_handles; i++) {
 			if (unlikely(get_user(syncobj_handles_stack[i],
 					      user_handles + i)))
@@ -361,22 +361,21 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 
 	for (i = 0U; i < num_syncobj_handles; i++) {
 		uint32_t handle = syncobj_handles[i];
-		bool seen = false;
-		uint32_t j;
+		uint32_t slot;
 
 		if (unlikely(handle == 0U)) {
 			ret = -EINVAL;
 			break;
 		}
 
-		for (j = 0U; j < recent_valid; j++) {
-			if (recent_handles[j] == handle) {
-				seen = true;
-				break;
-			}
-		}
-		if (seen)
+		if (handle == last_handle)
 			continue;
+
+		slot = handle & 7U;
+		if ((recent_valid & (1U << slot)) && recent_handles[slot] == handle) {
+			last_handle = handle;
+			continue;
+		}
 
 		ret = drm_syncobj_find_fence(filp, handle, 0, 0, &fence);
 		if (unlikely(ret))
@@ -390,10 +389,9 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 		if (unlikely(ret))
 			break;
 
-		recent_handles[recent_pos] = handle;
-		recent_pos = (recent_pos + 1U) & 3U;
-		if (recent_valid < ARRAY_SIZE(recent_handles))
-			recent_valid++;
+		recent_handles[slot] = handle;
+		recent_valid |= (uint8_t)(1U << slot);
+		last_handle = handle;
 	}
 
 	if (syncobj_handles!= syncobj_handles_stack)

--- a/kernel-raptorlake-experiments/618/amdgpu_ttm.c
+++ b/kernel-raptorlake-experiments/618/amdgpu_ttm.c
@@ -179,7 +179,6 @@ static int amdgpu_ttm_map_buffer(struct ttm_buffer_object *bo,
 	struct amdgpu_job *job;
 	void *cpu_addr;
 	uint64_t flags;
-	unsigned int i;
 	int r;
 
 	BUG_ON(adev->mman.buffer_funcs->copy_max_bytes <
@@ -232,20 +231,33 @@ static int amdgpu_ttm_map_buffer(struct ttm_buffer_object *bo,
 	} else {
 		dma_addr_t dma_address = mm_cur->start + adev->vm_manager.vram_base_offset;
 		dma_addr_t batch[256];
-		unsigned int page_idx = 0;
-		unsigned int batch_cnt = 0;
+		unsigned int page_idx = 0U;
+		unsigned int batch_cnt;
 
-		for (i = 0; i < num_pages; ++i) {
-			batch[batch_cnt++] = dma_address;
-			dma_address += PAGE_SIZE;
-			if (unlikely(batch_cnt == ARRAY_SIZE(batch) || i == num_pages - 1U)) {
-				amdgpu_gart_map(adev, (uint64_t)page_idx << PAGE_SHIFT,
-						batch_cnt, batch, flags, cpu_addr);
-				page_idx += batch_cnt;
-				batch_cnt = 0;
+		if (likely(num_pages <= ARRAY_SIZE(batch))) {
+			for (batch_cnt = 0U; batch_cnt < num_pages; ++batch_cnt) {
+				batch[batch_cnt] = dma_address;
+				dma_address += PAGE_SIZE;
 			}
+			amdgpu_gart_map(adev, 0, num_pages, batch, flags, cpu_addr);
+			goto out_submit;
+		}
+
+		while (page_idx < num_pages) {
+			unsigned int chunk = min_t(unsigned int, num_pages - page_idx,
+						   (unsigned int)ARRAY_SIZE(batch));
+
+			for (batch_cnt = 0U; batch_cnt < chunk; ++batch_cnt) {
+				batch[batch_cnt] = dma_address;
+				dma_address += PAGE_SIZE;
+			}
+
+			amdgpu_gart_map(adev, (uint64_t)page_idx << PAGE_SHIFT,
+					chunk, batch, flags, cpu_addr);
+			page_idx += chunk;
 		}
 	}
+out_submit:
 	dma_fence_put(amdgpu_job_submit(job));
 	return 0;
 }
@@ -331,6 +343,11 @@ int amdgpu_ttm_copy_mem_to_mem(struct amdgpu_device *adev,
 			uint64_t idx = (src_mm.start >> PAGE_SHIFT) + 16;
 			if (idx < src->bo->ttm->num_pages)
 				__builtin_prefetch(&src->bo->ttm->dma_address[idx], 0, 1);
+		}
+		if (dst->mem->mem_type == TTM_PL_TT) {
+			uint64_t idx = (dst_mm.start >> PAGE_SHIFT) + 16;
+			if (idx < dst->bo->ttm->num_pages)
+				__builtin_prefetch(&dst->bo->ttm->dma_address[idx], 1, 1);
 		}
 
 		r = amdgpu_ttm_map_buffer(src->bo, src->mem, &src_mm,
@@ -436,6 +453,7 @@ bool amdgpu_res_cpu_visible(struct amdgpu_device *adev,
 			    struct ttm_resource *res)
 {
 	struct amdgpu_res_cursor cursor;
+	uint64_t visible_vram_size;
 
 	if (!res)
 		return false;
@@ -456,16 +474,18 @@ bool amdgpu_res_cpu_visible(struct amdgpu_device *adev,
 	if (amdgpu_gmc_vram_full_visible(&adev->gmc))
 		return true;
 
+	visible_vram_size = adev->gmc.visible_vram_size;
+
 	/* Contiguous fast path – eliminates cursor walk (2 cache misses) */
 	if (likely(res->placement & TTM_PL_FLAG_CONTIGUOUS)) {
 		uint64_t start = (uint64_t)res->start << PAGE_SHIFT;
 		uint64_t end = start + res->size;
-		return end <= adev->gmc.visible_vram_size;
+		return end <= visible_vram_size;
 	}
 
 	amdgpu_res_first(res, 0, res->size, &cursor);
 	while (cursor.remaining) {
-		if (unlikely((cursor.start + cursor.size) > adev->gmc.visible_vram_size))
+		if (unlikely((cursor.start + cursor.size) > visible_vram_size))
 			return false;
 		amdgpu_res_next(&cursor, cursor.size);
 	}


### PR DESCRIPTION
### Motivation

- Reduce per-submission and BO-mapping CPU overhead that impacts frame-time stability and low-percentile FPS on CPU-bound workloads (targets: Vega 64 + i7-14700KF). 
- Eliminate small, frequent branch/memory stalls in syncobj handling and GART mapping hot paths to improve driver-side submission throughput. 
- Keep behavior, synchronization semantics and error paths unchanged while making small, cache/branch-friendly codegen improvements.

### Description

- `amdgpu_gem.c`: optimize `amdgpu_gem_add_input_fence()` by expanding the small-handle fast-path to 8 entries, replacing the linear recent-handle scan with a tiny direct-mapped 8-slot cache plus a consecutive-handle bypass to avoid redundant `drm_syncobj_find_fence()` and `dma_fence_wait()` work. (hot-path change only, semantics preserved).
- `amdgpu_ttm.c`: optimize `amdgpu_ttm_map_buffer()` by adding a single-chunk fast path for `num_pages <= 256` and converting the generic mapping to a chunked loop to reduce unpredictable branch/loop overhead when building GART batches. 
- `amdgpu_ttm.c`: add destination-side TTM DMA-address prefetch in `amdgpu_ttm_copy_mem_to_mem()` so both source and destination DMA metadata are warmed before mapping/copy. 
- `amdgpu_ttm.c`: hoist `adev->gmc.visible_vram_size` into a local `visible_vram_size` in `amdgpu_res_cpu_visible()` to avoid repeated dereferences inside cursor walks.
- Minor cleanup: removed an unused local and reorganized the mapping loop for clearer control flow and fewer branches; all changes confined to the two files and preserve ABI/behavior.

### Testing

- Ran automated repository checks: `git diff --check` (no whitespace/merge errors) — success. 
- Patch application and commit operations were performed automatically and completed successfully. 
- No full kernel build or Clang-22 -O3 LTO compile was executed in this environment; a full build and runtime profiling are recommended before upstream submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef92eb6750832abd59143375c1b654)