### PR TITLE
amdgpu: reduce submission overhead and improve ring/GART buffer handling

### DIFF
--- a/kernel-raptorlake-experiments/618/amdgpu_gem.c
+++ b/kernel-raptorlake-experiments/618/amdgpu_gem.c
@@ -303,9 +303,9 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 	uint32_t *syncobj_handles = NULL;
 	uint32_t __user *user_handles;
 	struct dma_fence *fence;
-	uint32_t recent_handles[4] = { 0U, 0U };
-	uint32_t recent_valid = 0U;
-	uint32_t recent_pos = 0U;
+	uint32_t recent_handles[8] = { 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U };
+	uint8_t recent_valid = 0U;
+	uint32_t last_handle = 0U;
 	uint32_t single_handle;
 	int ret = 0;
 	uint32_t i;
@@ -336,7 +336,7 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 		return ret;
 	}
 
-	if (likely(num_syncobj_handles <= 4U)) {
+	if (likely(num_syncobj_handles <= 8U)) {
 		for (i = 0U; i < num_syncobj_handles; i++) {
 			if (unlikely(get_user(syncobj_handles_stack[i],
 					      user_handles + i)))
@@ -361,22 +361,21 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 
 	for (i = 0U; i < num_syncobj_handles; i++) {
 		uint32_t handle = syncobj_handles[i];
-		bool seen = false;
-		uint32_t j;
+		uint32_t slot;
 
 		if (unlikely(handle == 0U)) {
 			ret = -EINVAL;
 			break;
 		}
 
-		for (j = 0U; j < recent_valid; j++) {
-			if (recent_handles[j] == handle) {
-				seen = true;
-				break;
-			}
-		}
-		if (seen)
+		if (handle == last_handle)
 			continue;
+
+		slot = handle & 7U;
+		if ((recent_valid & (1U << slot)) && recent_handles[slot] == handle) {
+			last_handle = handle;
+			continue;
+		}
 
 		ret = drm_syncobj_find_fence(filp, handle, 0, 0, &fence);
 		if (unlikely(ret))
@@ -390,10 +389,9 @@ amdgpu_gem_add_input_fence(struct drm_file *filp,
 		if (unlikely(ret))
 			break;
 
-		recent_handles[recent_pos] = handle;
-		recent_pos = (recent_pos + 1U) & 3U;
-		if (recent_valid < ARRAY_SIZE(recent_handles))
-			recent_valid++;
+		recent_handles[slot] = handle;
+		recent_valid |= (uint8_t)(1U << slot);
+		last_handle = handle;
 	}
 
 	if (syncobj_handles!= syncobj_handles_stack)

--- a/kernel-raptorlake-experiments/618/amdgpu_ttm.c
+++ b/kernel-raptorlake-experiments/618/amdgpu_ttm.c
@@ -179,7 +179,6 @@ static int amdgpu_ttm_map_buffer(struct ttm_buffer_object *bo,
 	struct amdgpu_job *job;
 	void *cpu_addr;
 	uint64_t flags;
-	unsigned int i;
 	int r;
 
 	BUG_ON(adev->mman.buffer_funcs->copy_max_bytes <
@@ -232,20 +231,33 @@ static int amdgpu_ttm_map_buffer(struct ttm_buffer_object *bo,
 	} else {
 		dma_addr_t dma_address = mm_cur->start + adev->vm_manager.vram_base_offset;
 		dma_addr_t batch[256];
-		unsigned int page_idx = 0;
-		unsigned int batch_cnt = 0;
+		unsigned int page_idx = 0U;
+		unsigned int batch_cnt;
 
-		for (i = 0; i < num_pages; ++i) {
-			batch[batch_cnt++] = dma_address;
-			dma_address += PAGE_SIZE;
-			if (unlikely(batch_cnt == ARRAY_SIZE(batch) || i == num_pages - 1U)) {
-				amdgpu_gart_map(adev, (uint64_t)page_idx << PAGE_SHIFT,
-						batch_cnt, batch, flags, cpu_addr);
-				page_idx += batch_cnt;
-				batch_cnt = 0;
+		if (likely(num_pages <= ARRAY_SIZE(batch))) {
+			for (batch_cnt = 0U; batch_cnt < num_pages; ++batch_cnt) {
+				batch[batch_cnt] = dma_address;
+				dma_address += PAGE_SIZE;
 			}
+			amdgpu_gart_map(adev, 0, num_pages, batch, flags, cpu_addr);
+			goto out_submit;
+		}
+
+		while (page_idx < num_pages) {
+			unsigned int chunk = min_t(unsigned int, num_pages - page_idx,
+						   (unsigned int)ARRAY_SIZE(batch));
+
+			for (batch_cnt = 0U; batch_cnt < chunk; ++batch_cnt) {
+				batch[batch_cnt] = dma_address;
+				dma_address += PAGE_SIZE;
+			}
+
+			amdgpu_gart_map(adev, (uint64_t)page_idx << PAGE_SHIFT,
+					chunk, batch, flags, cpu_addr);
+			page_idx += chunk;
 		}
 	}
+out_submit:
 	dma_fence_put(amdgpu_job_submit(job));
 	return 0;
 }
@@ -331,6 +343,11 @@ int amdgpu_ttm_copy_mem_to_mem(struct amdgpu_device *adev,
 			uint64_t idx = (src_mm.start >> PAGE_SHIFT) + 16;
 			if (idx < src->bo->ttm->num_pages)
 				__builtin_prefetch(&src->bo->ttm->dma_address[idx], 0, 1);
+		}
+		if (dst->mem->mem_type == TTM_PL_TT) {
+			uint64_t idx = (dst_mm.start >> PAGE_SHIFT) + 16;
+			if (idx < dst->bo->ttm->num_pages)
+				__builtin_prefetch(&dst->bo->ttm->dma_address[idx], 1, 1);
 		}
 
 		r = amdgpu_ttm_map_buffer(src->bo, src->mem, &src_mm,
@@ -436,6 +453,7 @@ bool amdgpu_res_cpu_visible(struct amdgpu_device *adev,
 			    struct ttm_resource *res)
 {
 	struct amdgpu_res_cursor cursor;
+	uint64_t visible_vram_size;
 
 	if (!res)
 		return false;
@@ -456,16 +474,18 @@ bool amdgpu_res_cpu_visible(struct amdgpu_device *adev,
 	if (amdgpu_gmc_vram_full_visible(&adev->gmc))
 		return true;
 
+	visible_vram_size = adev->gmc.visible_vram_size;
+
 	/* Contiguous fast path – eliminates cursor walk (2 cache misses) */
 	if (likely(res->placement & TTM_PL_FLAG_CONTIGUOUS)) {
 		uint64_t start = (uint64_t)res->start << PAGE_SHIFT;
 		uint64_t end = start + res->size;
-		return end <= adev->gmc.visible_vram_size;
+		return end <= visible_vram_size;
 	}
 
 	amdgpu_res_first(res, 0, res->size, &cursor);
 	while (cursor.remaining) {
-		if (unlikely((cursor.start + cursor.size) > adev->gmc.visible_vram_size))
+		if (unlikely((cursor.start + cursor.size) > visible_vram_size))
 			return false;
 		amdgpu_res_next(&cursor, cursor.size);
 	}

--- a/kernel-raptorlake-experiments/618/gfx_v9_0.c
+++ b/kernel-raptorlake-experiments/618/gfx_v9_0.c
@@ -180,6 +180,7 @@ gfx9_wait_reg_off(struct amdgpu_device *adev, u32 reg_offset,
 {
 	u32 val;
 	ktime_t deadline;
+	const bool atomic_ctx = in_atomic() || irqs_disabled();
 
 	if (unlikely(!adev))
 		return -EINVAL;
@@ -194,7 +195,7 @@ gfx9_wait_reg_off(struct amdgpu_device *adev, u32 reg_offset,
 		if ((val & mask) == val_target)
 			return 0;
 
-		if (in_atomic() || irqs_disabled()) {
+		if (atomic_ctx) {
 			udelay(1);
 			cpu_relax();
 		} else {
@@ -5509,6 +5510,7 @@ static void gfx_v9_0_ring_emit_hdp_flush(struct amdgpu_ring *ring)
 	struct amdgpu_device *adev = ring->adev;
 	u32 ref_and_mask, reg_mem_engine;
 	const struct nbio_hdp_flush_reg *nbio_hf_reg = adev->nbio.hdp_flush_reg;
+	u32 req_off, done_off;
 
 	if (ring->funcs->type == AMDGPU_RING_TYPE_COMPUTE) {
 		switch (ring->me) {
@@ -5527,9 +5529,11 @@ static void gfx_v9_0_ring_emit_hdp_flush(struct amdgpu_ring *ring)
 		reg_mem_engine = 1; /* pfp */
 	}
 
+	req_off = adev->nbio.funcs->get_hdp_flush_req_offset(adev);
+	done_off = adev->nbio.funcs->get_hdp_flush_done_offset(adev);
+
 	gfx_v9_0_wait_reg_mem(ring, reg_mem_engine, 0, 1,
-			      adev->nbio.funcs->get_hdp_flush_req_offset(adev),
-			      adev->nbio.funcs->get_hdp_flush_done_offset(adev),
+			      req_off, done_off,
 			      ref_and_mask, ref_and_mask, 0x20);
 }
 
@@ -5540,25 +5544,29 @@ static void gfx_v9_0_ring_emit_ib_gfx(struct amdgpu_ring *ring,
 {
 	unsigned vmid = AMDGPU_JOB_GET_VMID(job);
 	u32 header, control = 0;
+	const bool preempt = ib->flags & AMDGPU_IB_FLAG_PREEMPT;
+	const bool preempted = flags & AMDGPU_IB_PREEMPTED;
+	const bool use_ce = ib->flags & AMDGPU_IB_FLAG_CE;
+	const u32 ib_addr_lo = lower_32_bits(ib->gpu_addr);
+	const u32 ib_addr_hi = upper_32_bits(ib->gpu_addr);
 
-	if (ib->flags & AMDGPU_IB_FLAG_CE)
+	if (use_ce)
 		header = PACKET3(PACKET3_INDIRECT_BUFFER_CONST, 2);
 	else
 		header = PACKET3(PACKET3_INDIRECT_BUFFER, 2);
 
 	control |= ib->length_dw | (vmid << 24);
 
-	if (ib->flags & AMDGPU_IB_FLAG_PREEMPT) {
+	if (preempt) {
 		control |= INDIRECT_BUFFER_PRE_ENB(1);
 
-		if (flags & AMDGPU_IB_PREEMPTED)
+		if (preempted)
 			control |= INDIRECT_BUFFER_PRE_RESUME(1);
 
-		if (!(ib->flags & AMDGPU_IB_FLAG_CE) && vmid)
+		if (!use_ce && vmid)
 			gfx_v9_0_ring_emit_de_meta(ring,
-						   (!amdgpu_sriov_vf(ring->adev) &&
-						   flags & AMDGPU_IB_PREEMPTED) ?
-						   true : false,
+						   !amdgpu_sriov_vf(ring->adev) &&
+						   preempted,
 						   job->gds_size > 0 && job->gds_base != 0);
 	}
 
@@ -5568,8 +5576,8 @@ static void gfx_v9_0_ring_emit_ib_gfx(struct amdgpu_ring *ring,
 #ifdef __BIG_ENDIAN
 		(2 << 0) |
 #endif
-		lower_32_bits(ib->gpu_addr));
-	amdgpu_ring_write(ring, upper_32_bits(ib->gpu_addr));
+		ib_addr_lo);
+	amdgpu_ring_write(ring, ib_addr_hi);
 	amdgpu_ring_ib_on_emit_cntl(ring);
 	amdgpu_ring_write(ring, control);
 }
@@ -5583,28 +5591,39 @@ static void gfx_v9_0_ring_patch_cntl(struct amdgpu_ring *ring,
 	ring->ring[offset] = control;
 }
 
+static __always_inline void gfx_v9_0_ring_patch_payload(struct amdgpu_ring *ring,
+							 unsigned offset,
+							 const void *payload,
+							 size_t payload_size)
+{
+	size_t ring_bytes = (size_t)(ring->buf_mask + 1) << 2;
+	size_t start_byte = (size_t)offset << 2;
+	size_t first_copy;
+	u8 *ring_u8 = (u8 *)ring->ring;
+
+	if (start_byte + payload_size <= ring_bytes) {
+		memcpy(&ring_u8[start_byte], payload, payload_size);
+		return;
+	}
+
+	first_copy = ring_bytes - start_byte;
+	memcpy(&ring_u8[start_byte], payload, first_copy);
+	memcpy(&ring_u8[0], (const u8 *)payload + first_copy, payload_size - first_copy);
+}
+
 static void gfx_v9_0_ring_patch_ce_meta(struct amdgpu_ring *ring,
 					unsigned offset)
 {
 	struct amdgpu_device *adev = ring->adev;
 	void *ce_payload_cpu_addr;
-	uint64_t payload_offset, payload_size;
+	size_t payload_offset, payload_size;
 
 	payload_size = sizeof(struct v9_ce_ib_state);
 
 	payload_offset = offsetof(struct v9_gfx_meta_data, ce_payload);
-	ce_payload_cpu_addr = adev->virt.csa_cpu_addr + payload_offset;
+	ce_payload_cpu_addr = (u8 *)adev->virt.csa_cpu_addr + payload_offset;
 
-	if (offset + (payload_size >> 2) <= ring->buf_mask + 1) {
-		memcpy((void *)&ring->ring[offset], ce_payload_cpu_addr, payload_size);
-	} else {
-		memcpy((void *)&ring->ring[offset], ce_payload_cpu_addr,
-		       (ring->buf_mask + 1 - offset) << 2);
-		payload_size -= (ring->buf_mask + 1 - offset) << 2;
-		memcpy((void *)&ring->ring[0],
-		       ce_payload_cpu_addr + ((ring->buf_mask + 1 - offset) << 2),
-		       payload_size);
-	}
+	gfx_v9_0_ring_patch_payload(ring, offset, ce_payload_cpu_addr, payload_size);
 }
 
 static void gfx_v9_0_ring_patch_de_meta(struct amdgpu_ring *ring,
@@ -5612,26 +5631,17 @@ static void gfx_v9_0_ring_patch_de_meta(struct amdgpu_ring *ring,
 {
 	struct amdgpu_device *adev = ring->adev;
 	void *de_payload_cpu_addr;
-	uint64_t payload_offset, payload_size;
+	size_t payload_offset, payload_size;
 
 	payload_size = sizeof(struct v9_de_ib_state);
 
 	payload_offset = offsetof(struct v9_gfx_meta_data, de_payload);
-	de_payload_cpu_addr = adev->virt.csa_cpu_addr + payload_offset;
+	de_payload_cpu_addr = (u8 *)adev->virt.csa_cpu_addr + payload_offset;
 
 	((struct v9_de_ib_state *)de_payload_cpu_addr)->ib_completion_status =
 		IB_COMPLETION_STATUS_PREEMPTED;
 
-	if (offset + (payload_size >> 2) <= ring->buf_mask + 1) {
-		memcpy((void *)&ring->ring[offset], de_payload_cpu_addr, payload_size);
-	} else {
-		memcpy((void *)&ring->ring[offset], de_payload_cpu_addr,
-		       (ring->buf_mask + 1 - offset) << 2);
-		payload_size -= (ring->buf_mask + 1 - offset) << 2;
-		memcpy((void *)&ring->ring[0],
-		       de_payload_cpu_addr + ((ring->buf_mask + 1 - offset) << 2),
-		       payload_size);
-	}
+	gfx_v9_0_ring_patch_payload(ring, offset, de_payload_cpu_addr, payload_size);
 }
 
 static void gfx_v9_0_ring_emit_ib_compute(struct amdgpu_ring *ring,
@@ -5641,6 +5651,8 @@ static void gfx_v9_0_ring_emit_ib_compute(struct amdgpu_ring *ring,
 {
 	unsigned vmid = AMDGPU_JOB_GET_VMID(job);
 	u32 control = INDIRECT_BUFFER_VALID | ib->length_dw | (vmid << 24);
+	const u32 ib_addr_lo = lower_32_bits(ib->gpu_addr);
+	const u32 ib_addr_hi = upper_32_bits(ib->gpu_addr);
 
 	/* Currently, there is a high possibility to get wave ID mismatch
 	 * between ME and GDS, leading to a hw deadlock, because ME generates
@@ -5664,8 +5676,8 @@ static void gfx_v9_0_ring_emit_ib_compute(struct amdgpu_ring *ring,
 #ifdef __BIG_ENDIAN
 				(2 << 0) |
 #endif
-				lower_32_bits(ib->gpu_addr));
-	amdgpu_ring_write(ring, upper_32_bits(ib->gpu_addr));
+				ib_addr_lo);
+	amdgpu_ring_write(ring, ib_addr_hi);
 	amdgpu_ring_write(ring, control);
 }
 


### PR DESCRIPTION
### Motivation

- Reduce per-submission CPU overhead and improve duplicate-fence handling for common cases.  
- Improve GART mapping performance and reduce branch/memory churn when mapping pages.  
- Simplify and harden ring emit/patch code to avoid repeated work and correctly handle wrapped ring buffer copies.

### Description

- amdgpu_gem.c: Expanded fast-path dedup cache from 4 to 8 entries and replaced linear search with a small slot/hash+bitmask scheme, added `last_handle` short-circuit to avoid re-checking the immediately previous handle, and raised the stack-copy threshold to 8 handles.  
- amdgpu_ttm.c: Optimized `amdgpu_ttm_map_buffer` GART mapping to handle the common case where `num_pages` fits in the local `batch` array with a single call and otherwise iterate in chunked loops; added prefetch for destination pages in `amdgpu_ttm_copy_mem_to_mem`; refactored some locals and replaced magic literals with `ARRAY_SIZE`/typed variables.  
- gfx_v9_0.c: Cache atomic-context check in `gfx9_wait_reg_off`; extract HDP flush offsets to locals; precompute flags and address_lo/hi in IB emit functions; introduce `gfx_v9_0_ring_patch_payload` to handle wrapped ring buffer copies and replace ad-hoc memcpy logic in CE/DE meta patching; adjust several type casts to `size_t` and byte-pointer arithmetic to avoid pointer math issues.

### Testing

- Built the kernel targets including the modified drivers with `make -j$(nproc)` which succeeded.  
- Ran `sparse` and `scripts/checkpatch.pl` on changed files with no blocking warnings.  
- Per-file unit/compile checks for the amdgpu module completed successfully (no compile-time errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef92eb6750832abd59143375c1b654)