### PR TITLE
aco_optimizer: tighten loop-header phi temp propagation

### DIFF
--- a/vega-experiments/aco_optimizer.cpp
+++ b/vega-experiments/aco_optimizer.cpp
@@ -6888,13 +6888,18 @@ void rename_loop_header_phis(opt_ctx& ctx) {
             break;
 
          for (unsigned i = 0; i < instr->operands.size(); i++) {
-            if (!instr->operands[i].isTemp())
+            Operand& operand = instr->operands[i];
+            if (!operand.isTemp())
                continue;
 
-            ssa_info info = ctx.info[instr->operands[i].tempId()];
-            while (info.is_temp()) {
+            Temp cur = operand.getTemp();
+            const RegClass cls = cur.regClass();
+            while (true) {
+               const ssa_info& info = ctx.info[cur.id()];
+               if (!info.is_temp() || info.temp.regClass() != cls)
+                  break;
                pseudo_propagate_temp(ctx, instr, info.temp, i);
-               info = ctx.info[info.temp.id()];
+               cur = info.temp;
             }
          }
       }


### PR DESCRIPTION
### Motivation
- Reduce CPU work and improve predictability in a hot ACO optimizer path by tightening temp propagation for loop-header PHI operands, avoiding redundant metadata copies and preventing propagation across incompatible register classes.

### Description
- In `rename_loop_header_phis(opt_ctx&)` replace repeated operand indexing and `ssa_info` copies with a per-operand reference and an iterative temp-chain walk that checks the `RegClass` of chained temps before calling `pseudo_propagate_temp`, stopping when the chain ends or reg classes differ.

### Testing
- Performed automated whitespace/lint checks with no issues detected, and attempted a `clang++ -std=gnu++23` syntax-only build with the specified warning flags which failed in this environment due to missing project include paths (`aco_builder.h`); please validate with a full in-tree build to confirm a warning-clean compile and run the project test/build pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e146c770832aafbd9819d555a90b)