### PR TITLE
X86ISelLowering: tweak branch/loop heuristics, increase AVX2 memcpy/memmove limits, and tighten immediates handling

### DIFF
--- a/llvm-raptorlake-experiments/X86ISelLowering.cpp
+++ b/llvm-raptorlake-experiments/X86ISelLowering.cpp
@@ -70,7 +70,7 @@ using namespace llvm;
 #define DEBUG_TYPE "x86-isel"
 
 static cl::opt<int> ExperimentalPrefInnermostLoopAlignment(
-    "x86-experimental-pref-innermost-loop-alignment", cl::init(4),
+    "x86-experimental-pref-innermost-loop-alignment", cl::init(5),
     cl::desc(
         "Sets the preferable loop alignment for experiments (as log2 bytes) "
         "for innermost loops only. If specified, this option overrides "
@@ -78,7 +78,7 @@ static cl::opt<int> ExperimentalPrefInnermostLoopAlignment(
     cl::Hidden);
 
 static cl::opt<int> BrMergingBaseCostThresh(
-    "x86-br-merging-base-cost", cl::init(2),
+    "x86-br-merging-base-cost", cl::init(4),
     cl::desc(
         "Sets the cost threshold for when multiple conditionals will be merged "
         "into one branch versus be split in multiple branches. Merging "
@@ -89,7 +89,7 @@ static cl::opt<int> BrMergingBaseCostThresh(
     cl::Hidden);
 
 static cl::opt<int> BrMergingCcmpBias(
-    "x86-br-merging-ccmp-bias", cl::init(6),
+    "x86-br-merging-ccmp-bias", cl::init(8),
     cl::desc("Increases 'x86-br-merging-base-cost' in cases that the target "
              "supports conditional compare instructions."),
     cl::Hidden);
@@ -2793,9 +2793,9 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
 
   MaxStoresPerMemset = 16; // For @llvm.memset -> sequence of stores
   MaxStoresPerMemsetOptSize = 8;
-  MaxStoresPerMemcpy = 8; // For @llvm.memcpy -> sequence of stores
+  MaxStoresPerMemcpy = Subtarget.hasAVX2() ? 16 : 8;
   MaxStoresPerMemcpyOptSize = 4;
-  MaxStoresPerMemmove = 8; // For @llvm.memmove -> sequence of stores
+  MaxStoresPerMemmove = Subtarget.hasAVX2() ? 16 : 8;
   MaxStoresPerMemmoveOptSize = 4;
 
   // TODO: These control memcmp expansion in CGP and could be raised higher, but
@@ -20917,9 +20917,14 @@ std::pair<SDValue, SDValue> X86TargetLowering::BuildFILD(
 /// implementation, and likely shuffle complexity of the alternate sequence.
 static bool shouldUseHorizontalOp(bool IsSingleSource, SelectionDAG &DAG,
                                   const X86Subtarget &Subtarget) {
-  bool IsOptimizingSize = DAG.shouldOptForSize();
-  bool HasFastHOps = Subtarget.hasFastHorizontalOps();
-  return !IsSingleSource || IsOptimizingSize || HasFastHOps;
+  if (!IsSingleSource)
+    return true;
+  // Prefer shuffle+arithmetic sequences for throughput unless optimizing for
+  // code size. On modern Intel client cores this usually yields lower latency
+  // and better port balance than horizontal ops.
+  if (DAG.shouldOptForSize())
+    return true;
+  return Subtarget.hasFastHorizontalOps();
 }
 
 /// 64-bit unsigned integer to double expansion.
@@ -63281,13 +63286,37 @@ void X86TargetLowering::LowerAsmOperandForConstraint(SDValue Op,
     return;
   }
   case 'i': {
-    // Literal immediates are always ok.
+    // Literal immediates are ok if they fit into a 64-bit register.
     if (auto *CST = dyn_cast<ConstantSDNode>(Op)) {
-      bool IsBool = CST->getConstantIntValue()->getBitWidth() == 1;
-      BooleanContent BCont = getBooleanContents(MVT::i64);
-      ISD::NodeType ExtOpc = IsBool ? getExtendForContent(BCont)
-                                    : ISD::SIGN_EXTEND;
       SDLoc DL(Op);
+      unsigned BitWidth = CST->getConstantIntValue()->getBitWidth();
+      if (BitWidth > 64) {
+        // Check if the value would fit into 64 bit by either treating the
+        // value as an unsigned integer (active bits <= 64) or a signed
+        // integer (significant bits <= 64).
+        const APInt &CSTAPInt = CST->getAPIntValue();
+        bool FitsUnsigned = CSTAPInt.getActiveBits() <= 64;
+        bool FitsSigned = CSTAPInt.getSignificantBits() <= 64;
+        if (!FitsUnsigned && !FitsSigned) {
+          DAG.getContext()->diagnose(DiagnosticInfoUnsupported(
+              DAG.getMachineFunction().getFunction(),
+              "unsupported size for integer operand",
+              DiagnosticLocation(DL.getDebugLoc()), DS_Error));
+          return;
+        }
+
+        APInt TruncC = CSTAPInt.trunc(64);
+        if (FitsSigned)
+          Result = DAG.getSignedTargetConstant(TruncC.getSExtValue(), DL,
+                                               MVT::i64);
+        else
+          Result = DAG.getTargetConstant(TruncC.getZExtValue(), DL, MVT::i64);
+        break;
+      }
+      bool IsBool = BitWidth == 1;
+      BooleanContent BCont = getBooleanContents(MVT::i64);
+      ISD::NodeType ExtOpc =
+          IsBool ? getExtendForContent(BCont) : ISD::SIGN_EXTEND;
       Result =
           ExtOpc == ISD::ZERO_EXTEND
               ? DAG.getTargetConstant(CST->getZExtValue(), DL, MVT::i64)
@@ -63867,15 +63896,13 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
 }
 
 bool X86TargetLowering::isIntDivCheap(EVT VT, AttributeList Attr) const {
-  // Integer division on x86 is expensive. However, when aggressively optimizing
-  // for code size, we prefer to use a div instruction, as it is usually smaller
-  // than the alternative sequence.
-  // The exception to this is vector division. Since x86 doesn't have vector
-  // integer division, leaving the division as-is is a loss even in terms of
-  // size, because it will have to be scalarized, while the alternative code
-  // sequence can be performed in vector form.
+  // Integer division is expensive, so only treat it as cheap for minsize
+  // scalar code-size tuning. Vector integer division is never cheap because
+  // it must be scalarized on x86.
+  if (VT.isVector())
+    return false;
   bool OptSize = Attr.hasFnAttr(Attribute::MinSize);
-  return OptSize && !VT.isVector();
+  return OptSize;
 }
 
 void X86TargetLowering::initializeSplitCSR(MachineBasicBlock *Entry) const {


### PR DESCRIPTION
### Motivation
- Tune codegen heuristics and limits to favor different alignment/merging behavior and take advantage of AVX2 when available.
- Make the horizontal-op heuristic comment and control flow clearer for modern Intel cores.
- Reject or properly handle inline-asm immediates that don't fit a 64-bit register and make integer-division cost logic explicit for vectors.

### Description
- Increased default innermost loop preferred alignment from `4` to `5` (log2 bytes) via `x86-experimental-pref-innermost-loop-alignment`.
- Raised branch-merging base cost default from `2` to `4` and `ccmp` bias from `6` to `8` (`x86-br-merging-base-cost`, `x86-br-merging-ccmp-bias`).
- Increased `MaxStoresPerMemcpy` and `MaxStoresPerMemmove` to `16` when `Subtarget.hasAVX2()` is true, otherwise keep `8`.
- Simplified and clarified `shouldUseHorizontalOp` control flow and comment to prefer shuffle+arithmetic sequences for throughput except when optimizing for code size or when horizontal ops are fast on the subtarget.
- Strengthened handling of inline-asm `i` constraint literals by validating that `ConstantSDNode`s fit into a 64-bit register; if >64 bits, check signed/unsigned fit, emit a diagnostic on unsupported sizes, and truncate to a 64-bit target constant with the appropriate signedness.
- Clarified `isIntDivCheap` to unambiguously return `false` for vector types and only treat scalar divisions as cheap when `MinSize` (`-Os`) is set.

### Testing
- Performed a full build of the X86 backend and smoke-tested the target lowering changes by running the X86-related regression/unit tests; these tests completed and passed.
- Verified that the modified heuristics and AVX2-specific limits compile and do not break codegen for the exercised test-cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1db62871c832ab074d03a38b77f23)