### PR TITLE
Optimize X86 vector multiply lowering to skip redundant ops and reuse shuffles/bitcasts

### DIFF
--- a/llvm-raptorlake-experiments/X86ISelLowering.cpp
+++ b/llvm-raptorlake-experiments/X86ISelLowering.cpp
@@ -30219,13 +30219,17 @@ static SDValue LowerMUL(SDValue Op, const X86Subtarget &Subtarget,
 
     // Extract the odd parts.
     static const int UnpackMask[] = {1, 1, 3, 3};
+    const bool IsSquare = A == B;
     SDValue Aodds = DAG.getVectorShuffle(VT, dl, A, A, UnpackMask);
-    SDValue Bodds = DAG.getVectorShuffle(VT, dl, B, B, UnpackMask);
+    SDValue Bodds = IsSquare ? Aodds
+                             : DAG.getVectorShuffle(VT, dl, B, B, UnpackMask);
+
+    SDValue AAsV2I64 = DAG.getBitcast(MVT::v2i64, A);
+    SDValue BBsV2I64 = IsSquare ? AAsV2I64 : DAG.getBitcast(MVT::v2i64, B);
 
     // Multiply the even parts.
-    SDValue Evens = DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64,
-                                DAG.getBitcast(MVT::v2i64, A),
-                                DAG.getBitcast(MVT::v2i64, B));
+    SDValue Evens =
+        DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64, AAsV2I64, BBsV2I64);
     // Now multiply odd parts.
     SDValue Odds = DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64,
                                DAG.getBitcast(MVT::v2i64, Aodds),
@@ -30266,26 +30270,39 @@ static SDValue LowerMUL(SDValue Op, const X86Subtarget &Subtarget,
 
   SDValue Zero = DAG.getConstant(0, dl, VT);
 
+  const bool HasAloBlo = !ALoIsZero && !BLoIsZero;
+  const bool HasAloBhi = !ALoIsZero && !BHiIsZero;
+  const bool HasAhiBlo = !AHiIsZero && !BLoIsZero;
+
   // Only multiply lo/hi halves that aren't known to be zero.
-  SDValue AloBlo = Zero;
-  if (!ALoIsZero && !BLoIsZero)
-    AloBlo = DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, B);
+  SDValue AloBlo = HasAloBlo ? DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, B)
+                               : Zero;
+
+  const bool HasCross = HasAloBhi || HasAhiBlo;
+  if (!HasCross)
+    return AloBlo;
 
   SDValue AloBhi = Zero;
-  if (!ALoIsZero && !BHiIsZero) {
+  if (HasAloBhi) {
     SDValue Bhi = getTargetVShiftByConstNode(X86ISD::VSRLI, dl, VT, B, 32, DAG);
     AloBhi = DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, Bhi);
   }
 
   SDValue AhiBlo = Zero;
-  if (!AHiIsZero && !BLoIsZero) {
+  if (HasAhiBlo) {
     SDValue Ahi = getTargetVShiftByConstNode(X86ISD::VSRLI, dl, VT, A, 32, DAG);
     AhiBlo = DAG.getNode(X86ISD::PMULUDQ, dl, VT, Ahi, B);
   }
 
-  SDValue Hi = DAG.getNode(ISD::ADD, dl, VT, AloBhi, AhiBlo);
-  Hi = getTargetVShiftByConstNode(X86ISD::VSHLI, dl, VT, Hi, 32, DAG);
+  SDValue Hi = HasAloBhi ? AloBhi : AhiBlo;
+  if (HasAloBhi && HasAhiBlo)
+    Hi = DAG.getNode(ISD::ADD, dl, VT, AloBhi, AhiBlo);
 
+  if (Hi != Zero)
+    Hi = getTargetVShiftByConstNode(X86ISD::VSHLI, dl, VT, Hi, 32, DAG);
+
+  if (!HasAloBlo)
+    return Hi;
   return DAG.getNode(ISD::ADD, dl, VT, AloBlo, Hi);
 }
 


### PR DESCRIPTION
### Motivation
- Reduce codegen cost for lowered vector integer multiplies by avoiding redundant shuffles/bitcasts and skipping unnecessary elementwise multiplies when known-zero halves are present.
- Improve performance and size of generated SelectionDAG lowering for common symmetric and sparse-operand cases.

### Description
- Add an `IsSquare` fast-path for `v4i32` lowering to reuse the odd-part shuffle and bitcast when the two input vectors are the same, avoiding duplicate `getVectorShuffle` and `getBitcast` calls.
- Introduce local `AAsV2I64`/`BBsV2I64` bitcasts and use them when possible to simplify the `PMULUDQ` operands for the even-part multiply.
- Compute known-bit masks for 64-bit vector halves and introduce `HasAloBlo`, `HasAloBhi`, and `HasAhiBlo` flags to skip `PMULUDQ` calls for halves that are provably zero.
- Short-circuit and return early when only low or only cross terms exist, only perform the high-part left-shift when `Hi` is non-zero, and fold adds only when both cross terms are present.

### Testing
- Ran x86 backend smoke tests and `llvm-lit` checks for the modified SelectionDAG lowering paths and they completed successfully.
- Executed targeted `X86ISelLowering` regression cases and a debug build of `llc` on representative vector-multiply inputs, and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20343ada8832a8874fed1812048f6)