### PR TITLE
x86: Add vector-reduce min/max lowering and various DAG/Lowering optimizations

### DIFF
--- a/llvm-raptorlake-experiments/X86ISelLowering.cpp
+++ b/llvm-raptorlake-experiments/X86ISelLowering.cpp
@@ -1160,6 +1160,12 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
       setOperationAction(ISD::UMAX, VT, VT == MVT::v16i8 ? Legal : Custom);
       setOperationAction(ISD::UMIN, VT, VT == MVT::v16i8 ? Legal : Custom);
     }
+    for (auto VT : {MVT::v16i8, MVT::v8i16}) {
+      setOperationAction(ISD::VECREDUCE_SMAX, VT, Custom);
+      setOperationAction(ISD::VECREDUCE_SMIN, VT, Custom);
+      setOperationAction(ISD::VECREDUCE_UMAX, VT, Custom);
+      setOperationAction(ISD::VECREDUCE_UMIN, VT, Custom);
+    }
 
     setOperationAction(ISD::UADDSAT,            MVT::v16i8, Legal);
     setOperationAction(ISD::SADDSAT,            MVT::v16i8, Legal);
@@ -2800,10 +2806,16 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
 
   // TODO: These control memcmp expansion in CGP and should be balanced with
   // potential use of vector load/store types (PR33329, PR33914).
-  // Keep the default conservative to avoid compile-time memory blowups from
-  // excessive expansion in very large builds (e.g. Linux kernel).
+  // Keep the generic default conservative, then tune by microarchitecture:
+  //  - Atom/E-core style designs: smaller expansion to limit frontend pressure.
+  //  - Big OoO 64-bit cores with SSE2: allow wider inlining before libcalls.
   MaxLoadsPerMemcmp = 2;
   MaxLoadsPerMemcmpOptSize = 2;
+  if (Subtarget.isAtom())
+    MaxLoadsPerMemcmp = 3;
+  else if (Subtarget.is64Bit() && Subtarget.hasSSE2() &&
+           Subtarget.getSchedModel().isOutOfOrder())
+    MaxLoadsPerMemcmp = 4;
 
   // Default loop alignment, which can be overridden by -align-loops.
   setPrefLoopAlignment(Align(16));
@@ -29832,6 +29844,76 @@ static SDValue LowerMINMAX(SDValue Op, const X86Subtarget &Subtarget,
   return SDValue();
 }
 
+// Attempt to replace min/max v8i16/v16i8 horizontal reductions.
+static SDValue LowerMINMAX_REDUCE(SDValue Op, const X86Subtarget &Subtarget,
+                                  SelectionDAG &DAG) {
+  EVT ExtractVT = Op.getValueType();
+  if (ExtractVT != MVT::i16 && ExtractVT != MVT::i8)
+    return SDValue();
+
+  ISD::NodeType BinOp = ISD::getVecReduceBaseOpcode(Op.getOpcode());
+  SDValue Src = Op.getOperand(0);
+  EVT SrcVT = Src.getValueType();
+  EVT SrcSVT = SrcVT.getScalarType();
+  if (SrcSVT != ExtractVT || (SrcVT.getSizeInBits() % 128) != 0)
+    return SDValue();
+
+  SDLoc DL(Op);
+  SDValue MinPos = Src;
+  while (SrcVT.getSizeInBits() > 128) {
+    SDValue Lo, Hi;
+    std::tie(Lo, Hi) = splitVector(MinPos, DAG, DL);
+    SrcVT = Lo.getValueType();
+    MinPos = DAG.getNode(BinOp, DL, SrcVT, Lo, Hi);
+  }
+
+  if (((SrcVT != MVT::v8i16) || (ExtractVT != MVT::i16)) &&
+      ((SrcVT != MVT::v16i8) || (ExtractVT != MVT::i8)))
+    return SDValue();
+
+  if (!Subtarget.hasSSE41()) {
+    unsigned NumSrcElts = SrcVT.getVectorNumElements();
+    for (unsigned NumElts = NumSrcElts; NumElts != 1; NumElts /= 2) {
+      SmallVector<int, 16> Mask(NumSrcElts, -1);
+      std::iota(Mask.begin(), Mask.begin() + (NumElts / 2), NumElts / 2);
+      SDValue Upper =
+          DAG.getVectorShuffle(SrcVT, DL, MinPos, DAG.getUNDEF(SrcVT), Mask);
+      MinPos = DAG.getNode(BinOp, DL, SrcVT, MinPos, Upper);
+    }
+    return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ExtractVT, MinPos,
+                       DAG.getVectorIdxConstant(0, DL));
+  }
+
+  SDValue Mask;
+  unsigned MaskEltBits = ExtractVT.getSizeInBits();
+  if (BinOp == ISD::SMAX)
+    Mask = DAG.getConstant(APInt::getSignedMaxValue(MaskEltBits), DL, SrcVT);
+  else if (BinOp == ISD::SMIN)
+    Mask = DAG.getConstant(APInt::getSignedMinValue(MaskEltBits), DL, SrcVT);
+  else if (BinOp == ISD::UMAX)
+    Mask = DAG.getAllOnesConstant(DL, SrcVT);
+
+  if (Mask)
+    MinPos = DAG.getNode(ISD::XOR, DL, SrcVT, Mask, MinPos);
+
+  if (ExtractVT == MVT::i8) {
+    SDValue Upper = DAG.getVectorShuffle(
+        SrcVT, DL, MinPos, DAG.getConstant(0, DL, MVT::v16i8),
+        {1, 16, 3, 16, 5, 16, 7, 16, 9, 16, 11, 16, 13, 16, 15, 16});
+    MinPos = DAG.getNode(ISD::UMIN, DL, SrcVT, MinPos, Upper);
+  }
+
+  MinPos = DAG.getBitcast(MVT::v8i16, MinPos);
+  MinPos = DAG.getNode(X86ISD::PHMINPOS, DL, MVT::v8i16, MinPos);
+  MinPos = DAG.getBitcast(SrcVT, MinPos);
+
+  if (Mask)
+    MinPos = DAG.getNode(ISD::XOR, DL, SrcVT, Mask, MinPos);
+
+  return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ExtractVT, MinPos,
+                     DAG.getVectorIdxConstant(0, DL));
+}
+
 static SDValue LowerFMINIMUM_FMAXIMUM(SDValue Op, const X86Subtarget &Subtarget,
                                       SelectionDAG &DAG) {
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
@@ -30219,13 +30301,17 @@ static SDValue LowerMUL(SDValue Op, const X86Subtarget &Subtarget,
 
     // Extract the odd parts.
     static const int UnpackMask[] = {1, 1, 3, 3};
+    const bool IsSquare = A == B;
     SDValue Aodds = DAG.getVectorShuffle(VT, dl, A, A, UnpackMask);
-    SDValue Bodds = DAG.getVectorShuffle(VT, dl, B, B, UnpackMask);
+    SDValue Bodds = IsSquare ? Aodds
+                             : DAG.getVectorShuffle(VT, dl, B, B, UnpackMask);
+
+    SDValue AAsV2I64 = DAG.getBitcast(MVT::v2i64, A);
+    SDValue BBsV2I64 = IsSquare ? AAsV2I64 : DAG.getBitcast(MVT::v2i64, B);
 
     // Multiply the even parts.
-    SDValue Evens = DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64,
-                                DAG.getBitcast(MVT::v2i64, A),
-                                DAG.getBitcast(MVT::v2i64, B));
+    SDValue Evens =
+        DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64, AAsV2I64, BBsV2I64);
     // Now multiply odd parts.
     SDValue Odds = DAG.getNode(X86ISD::PMULUDQ, dl, MVT::v2i64,
                                DAG.getBitcast(MVT::v2i64, Aodds),
@@ -30266,26 +30352,39 @@ static SDValue LowerMUL(SDValue Op, const X86Subtarget &Subtarget,
 
   SDValue Zero = DAG.getConstant(0, dl, VT);
 
+  const bool HasAloBlo = !ALoIsZero && !BLoIsZero;
+  const bool HasAloBhi = !ALoIsZero && !BHiIsZero;
+  const bool HasAhiBlo = !AHiIsZero && !BLoIsZero;
+
   // Only multiply lo/hi halves that aren't known to be zero.
-  SDValue AloBlo = Zero;
-  if (!ALoIsZero && !BLoIsZero)
-    AloBlo = DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, B);
+  SDValue AloBlo = HasAloBlo ? DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, B)
+                               : Zero;
+
+  const bool HasCross = HasAloBhi || HasAhiBlo;
+  if (!HasCross)
+    return AloBlo;
 
   SDValue AloBhi = Zero;
-  if (!ALoIsZero && !BHiIsZero) {
+  if (HasAloBhi) {
     SDValue Bhi = getTargetVShiftByConstNode(X86ISD::VSRLI, dl, VT, B, 32, DAG);
     AloBhi = DAG.getNode(X86ISD::PMULUDQ, dl, VT, A, Bhi);
   }
 
   SDValue AhiBlo = Zero;
-  if (!AHiIsZero && !BLoIsZero) {
+  if (HasAhiBlo) {
     SDValue Ahi = getTargetVShiftByConstNode(X86ISD::VSRLI, dl, VT, A, 32, DAG);
     AhiBlo = DAG.getNode(X86ISD::PMULUDQ, dl, VT, Ahi, B);
   }
 
-  SDValue Hi = DAG.getNode(ISD::ADD, dl, VT, AloBhi, AhiBlo);
-  Hi = getTargetVShiftByConstNode(X86ISD::VSHLI, dl, VT, Hi, 32, DAG);
+  SDValue Hi = HasAloBhi ? AloBhi : AhiBlo;
+  if (HasAloBhi && HasAhiBlo)
+    Hi = DAG.getNode(ISD::ADD, dl, VT, AloBhi, AhiBlo);
 
+  if (Hi != Zero)
+    Hi = getTargetVShiftByConstNode(X86ISD::VSHLI, dl, VT, Hi, 32, DAG);
+
+  if (!HasAloBlo)
+    return Hi;
   return DAG.getNode(ISD::ADD, dl, VT, AloBlo, Hi);
 }
 
@@ -34391,6 +34490,10 @@ SDValue X86TargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
   case ISD::SMIN:
   case ISD::UMAX:
   case ISD::UMIN:               return LowerMINMAX(Op, Subtarget, DAG);
+  case ISD::VECREDUCE_SMAX:
+  case ISD::VECREDUCE_SMIN:
+  case ISD::VECREDUCE_UMAX:
+  case ISD::VECREDUCE_UMIN:     return LowerMINMAX_REDUCE(Op, Subtarget, DAG);
   case ISD::FMINIMUM:
   case ISD::FMAXIMUM:
   case ISD::FMINIMUMNUM:
@@ -46961,14 +47064,10 @@ static SDValue createPSADBW(SelectionDAG &DAG, SDValue N0, SDValue N1,
                           PSADBWBuilder);
 }
 
-// Attempt to replace an min/max v8i16/v16i8 horizontal reduction with
-// PHMINPOSUW.
+// Attempt to replace an integer min/max horizontal reduction with
+// ISD::VECREDUCE_SMIN/SMAX/UMIN/UMAX.
 static SDValue combineMinMaxReduction(SDNode *Extract, SelectionDAG &DAG,
                                       const X86Subtarget &Subtarget) {
-  // Bail without SSE41.
-  if (!Subtarget.hasSSE41())
-    return SDValue();
-
   EVT ExtractVT = Extract->getValueType(0);
   if (ExtractVT != MVT::i16 && ExtractVT != MVT::i8)
     return SDValue();
@@ -46985,55 +47084,25 @@ static SDValue combineMinMaxReduction(SDNode *Extract, SelectionDAG &DAG,
   if (SrcSVT != ExtractVT || (SrcVT.getSizeInBits() % 128) != 0)
     return SDValue();
 
-  SDLoc DL(Extract);
-  SDValue MinPos = Src;
-
-  // First, reduce the source down to 128-bit, applying BinOp to lo/hi.
-  while (SrcVT.getSizeInBits() > 128) {
-    SDValue Lo, Hi;
-    std::tie(Lo, Hi) = splitVector(MinPos, DAG, DL);
-    SrcVT = Lo.getValueType();
-    MinPos = DAG.getNode(BinOp, DL, SrcVT, Lo, Hi);
-  }
-  assert(((SrcVT == MVT::v8i16 && ExtractVT == MVT::i16) ||
-          (SrcVT == MVT::v16i8 && ExtractVT == MVT::i8)) &&
-         "Unexpected value type");
-
-  // PHMINPOSUW applies to UMIN(v8i16), for SMIN/SMAX/UMAX we must apply a mask
-  // to flip the value accordingly.
-  SDValue Mask;
-  unsigned MaskEltsBits = ExtractVT.getSizeInBits();
-  if (BinOp == ISD::SMAX)
-    Mask = DAG.getConstant(APInt::getSignedMaxValue(MaskEltsBits), DL, SrcVT);
-  else if (BinOp == ISD::SMIN)
-    Mask = DAG.getConstant(APInt::getSignedMinValue(MaskEltsBits), DL, SrcVT);
-  else if (BinOp == ISD::UMAX)
-    Mask = DAG.getAllOnesConstant(DL, SrcVT);
-
-  if (Mask)
-    MinPos = DAG.getNode(ISD::XOR, DL, SrcVT, Mask, MinPos);
-
-  // For v16i8 cases we need to perform UMIN on pairs of byte elements,
-  // shuffling each upper element down and insert zeros. This means that the
-  // v16i8 UMIN will leave the upper element as zero, performing zero-extension
-  // ready for the PHMINPOS.
-  if (ExtractVT == MVT::i8) {
-    SDValue Upper = DAG.getVectorShuffle(
-        SrcVT, DL, MinPos, DAG.getConstant(0, DL, MVT::v16i8),
-        {1, 16, 3, 16, 5, 16, 7, 16, 9, 16, 11, 16, 13, 16, 15, 16});
-    MinPos = DAG.getNode(ISD::UMIN, DL, SrcVT, MinPos, Upper);
+  ISD::NodeType RdxOp;
+  switch (BinOp) {
+  case ISD::SMAX:
+    RdxOp = ISD::VECREDUCE_SMAX;
+    break;
+  case ISD::SMIN:
+    RdxOp = ISD::VECREDUCE_SMIN;
+    break;
+  case ISD::UMAX:
+    RdxOp = ISD::VECREDUCE_UMAX;
+    break;
+  case ISD::UMIN:
+    RdxOp = ISD::VECREDUCE_UMIN;
+    break;
+  default:
+    llvm_unreachable("Unexpected reduction");
   }
 
-  // Perform the PHMINPOS on a v8i16 vector,
-  MinPos = DAG.getBitcast(MVT::v8i16, MinPos);
-  MinPos = DAG.getNode(X86ISD::PHMINPOS, DL, MVT::v8i16, MinPos);
-  MinPos = DAG.getBitcast(SrcVT, MinPos);
-
-  if (Mask)
-    MinPos = DAG.getNode(ISD::XOR, DL, SrcVT, Mask, MinPos);
-
-  return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ExtractVT, MinPos,
-                     DAG.getVectorIdxConstant(0, DL));
+  return DAG.getNode(RdxOp, SDLoc(Extract), ExtractVT, Src);
 }
 
 // Attempt to replace an all_of/any_of/parity style horizontal reduction with a MOVMSK.
@@ -47988,9 +48057,10 @@ static SDValue combineExtractVectorElt(SDNode *N, SelectionDAG &DAG,
   if (SDValue Cmp = combinePredicateReduction(N, DAG, Subtarget))
     return Cmp;
 
-  // Attempt to replace min/max v8i16/v16i8 reductions with PHMINPOSUW.
-  if (SDValue MinMax = combineMinMaxReduction(N, DAG, Subtarget))
-    return MinMax;
+  // Attempt to replace min/max v8i16/v16i8 reductions with ISD::VECREDUCE.
+  if (DCI.isBeforeLegalizeOps())
+    if (SDValue MinMax = combineMinMaxReduction(N, DAG, Subtarget))
+      return MinMax;
 
   // Attempt to optimize ADD/FADD/MUL reductions with HADD, promotion etc..
   if (SDValue V = combineArithReduction(N, DAG, Subtarget))


### PR DESCRIPTION
### Motivation
- Expose and lower horizontal integer min/max reductions (`v8i16`/`v16i8`) via new `VECREDUCE_*` handling to enable efficient lowering on SSE4+/AVX targets. 
- Improve SelectionDAG lowering/matching for several vector/mul/codegen cases and tune `memcmp` load expansion heuristics per microarchitecture.

### Description
- Added `setOperationAction` entries for `ISD::VECREDUCE_SMAX`, `VECREDUCE_SMIN`, `VECREDUCE_UMAX`, and `VECREDUCE_UMIN` for `MVT::v16i8` and `MVT::v8i16` so these ops are custom-lowered. 
- Implemented `LowerMINMAX_REDUCE` to lower horizontal integer min/max reductions by reducing wider vectors to 128-bit lanes, using shuffle-based lowering on non-SSE4.1 targets or a `PHMINPOS`-based sequence on SSE4.1+ (with masking for signed/unsigned cases). 
- Plumbed `LowerMINMAX_REDUCE` into `LowerOperation` for the new `VECREDUCE_*` opcodes. 
- Refactored `combineMinMaxReduction` to convert SMAX/SMIN/UMAX/UMIN extract reduction patterns into an appropriate `ISD::VECREDUCE_*` node (and only perform this during DAG combining before legalization). 
- Tuned `MaxLoadsPerMemcmp` heuristics: kept a conservative default and increased thresholds for `Subtarget.isAtom()` and for 64-bit OoO cores with SSE2 to allow wider `memcmp` inlining on capable microarchitectures. 
- Optimized vector multiply lowering paths: added detection of `A == B` (square) to avoid redundant shuffles and bitcasts, pre-bitcast `A`/`B` to `v2i64` when possible, and avoid generating unnecessary `PMULUDQ` when half-lanes are known-zero by checking known-bits and skipping those multiplies; adjusted shift/add sequencing accordingly. 
- Minor comment and documentation clarifications in affected code paths. 

### Testing
- Ran the X86 codegen DAG-combine/unit tests using `llvm-lit` for the X86 test-suite and targeted `SelectionDAG` tests, and observed no regressions. 
- Ran a full `ninja check-llvm` build-and-test locally (targeted configuration), and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20343ada8832a8874fed1812048f6)