### PR TITLE
Cache VKD3D_DISABLE_EXTENSIONS and early-filter disabled extensions

### DIFF
--- a/packages/vkd3d-proton-mingw-git/patches/device.c
+++ b/packages/vkd3d-proton-mingw-git/patches/device.c
@@ -181,14 +181,24 @@ static unsigned int get_spec_version(const VkExtensionProperties *extensions,
     return 0;
 }
 
+static char vkd3d_disabled_extensions[VKD3D_PATH_MAX];
+static bool vkd3d_has_disabled_extensions;
+static pthread_once_t vkd3d_disabled_extensions_once = PTHREAD_ONCE_INIT;
+
+static void vkd3d_init_disabled_extensions_once(void)
+{
+    vkd3d_has_disabled_extensions = vkd3d_get_env_var("VKD3D_DISABLE_EXTENSIONS",
+            vkd3d_disabled_extensions, sizeof(vkd3d_disabled_extensions));
+}
+
 static bool is_extension_disabled(const char *extension_name)
 {
-    char disabled_extensions[VKD3D_PATH_MAX];
+    pthread_once(&vkd3d_disabled_extensions_once, vkd3d_init_disabled_extensions_once);
 
-    if (!vkd3d_get_env_var("VKD3D_DISABLE_EXTENSIONS", disabled_extensions, sizeof(disabled_extensions)))
+    if (!vkd3d_has_disabled_extensions)
         return false;
 
-    return vkd3d_debug_list_has_member(disabled_extensions, extension_name);
+    return vkd3d_debug_list_has_member(vkd3d_disabled_extensions, extension_name);
 }
 
 static bool has_extension(const VkExtensionProperties *extensions,
@@ -196,13 +206,14 @@ static bool has_extension(const VkExtensionProperties *extensions,
 {
     unsigned int i;
 
+    if (is_extension_disabled(extension_name))
+    {
+        WARN("Extension %s is disabled.\n", debugstr_a(extension_name));
+        return false;
+    }
+
     for (i = 0; i < count; ++i)
     {
-        if (is_extension_disabled(extension_name))
-        {
-            WARN("Extension %s is disabled.\n", debugstr_a(extension_name));
-            continue;
-        }
         if (!strcmp(extensions[i].extensionName, extension_name) &&
                 (extensions[i].specVersion >= minimum_spec_version))
             return true;


### PR DESCRIPTION
### Motivation
- Reduce repeated environment lookups and make loading of `VKD3D_DISABLE_EXTENSIONS` thread-safe by initializing it once. 
- Ensure disabled extensions are filtered out before scanning available extension lists to avoid spurious warnings and unnecessary work.

### Description
- Add a static buffer `vkd3d_disabled_extensions`, boolean `vkd3d_has_disabled_extensions`, and a `pthread_once_t` `vkd3d_disabled_extensions_once` with initializer `vkd3d_init_disabled_extensions_once` to cache the env var. 
- Modify `is_extension_disabled` to perform one-time initialization via `pthread_once` and consult the cached value instead of calling the env lookup on each invocation. 
- Change `has_extension` to check `is_extension_disabled` before iterating extensions and emit a `WARN` and return false immediately if the extension is disabled, removing the per-entry check inside the loop.

### Testing
- Built the project using the normal build system (`meson`/`ninja`) and the build completed successfully. 
- Ran the existing automated test suite (`ninja test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb51455554832a992809632afaf883)