### PR TITLE
vkd3d-proton: synchronize AMD Anti‑Lag state reads in device_vkd3d_ext

### DIFF
--- a/packages/vkd3d-proton-mingw-git/patches/device_vkd3d_ext.c
+++ b/packages/vkd3d-proton-mingw-git/patches/device_vkd3d_ext.c
@@ -1187,6 +1187,9 @@ static HRESULT STDMETHODCALLTYPE d3d12_amd_ext_anti_lag_UpdateAntiLagState(
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     const struct AmdAntiLagAPIData_v1 *v1 = pData;
     const struct AmdAntiLagAPIData_v2 *v2 = pData;
+    uint64_t frame_index;
+    uint32_t max_fps;
+    bool mode;
 
     /* Don't try to use LL2 and AMD anti-lag at the same time. */
     if (!device->device_info.anti_lag_amd.antiLag || device->vk_info.NV_low_latency2)
@@ -1207,19 +1210,25 @@ static HRESULT STDMETHODCALLTYPE d3d12_amd_ext_anti_lag_UpdateAntiLagState(
         memset(&anti_lag, 0, sizeof(anti_lag));
         memset(&present_info, 0, sizeof(present_info));
         anti_lag.sType = VK_STRUCTURE_TYPE_ANTI_LAG_DATA_AMD;
-        anti_lag.mode = device->swapchain_info.mode ? VK_ANTI_LAG_MODE_ON_AMD : VK_ANTI_LAG_MODE_OFF_AMD;
-        anti_lag.maxFPS = device->swapchain_info.max_fps;
+        spinlock_acquire(&device->low_latency_swapchain_spinlock);
+        mode = device->swapchain_info.mode;
+        max_fps = device->swapchain_info.max_fps;
+        spinlock_release(&device->low_latency_swapchain_spinlock);
+        anti_lag.mode = mode ? VK_ANTI_LAG_MODE_ON_AMD : VK_ANTI_LAG_MODE_OFF_AMD;
+        anti_lag.maxFPS = max_fps;
         anti_lag.pPresentationInfo = &present_info;
 
         present_info.sType = VK_STRUCTURE_TYPE_ANTI_LAG_PRESENTATION_INFO_AMD;
-        present_info.frameIndex = device->frame_markers.present + 1;
+        frame_index = vkd3d_atomic_uint64_load_explicit(&device->frame_markers.present,
+                vkd3d_memory_order_acquire) + 1;
+        present_info.frameIndex = frame_index;
         present_info.stage = VK_ANTI_LAG_STAGE_INPUT_AMD;
 
         TRACE("AntiLag input timeline, frame %"PRIu64".\n", present_info.frameIndex);
-        if (device->swapchain_info.mode)
+        if (mode)
             cookie = vkd3d_queue_timeline_trace_register_low_latency_sleep(&device->queue_timeline_trace, present_info.frameIndex);
         VK_CALL(vkAntiLagUpdateAMD(device->vk_device, &anti_lag));
-        if (device->swapchain_info.mode)
+        if (mode)
             vkd3d_queue_timeline_trace_complete_low_latency_sleep(&device->queue_timeline_trace, cookie);
 
         /* Any present after this point will map to this frameIndex. */


### PR DESCRIPTION
### Motivation
- Fix a data‑race and ordering problem where `d3d12_amd_ext_anti_lag_UpdateAntiLagState()` read `swapchain_info.mode` and `swapchain_info.max_fps` without synchronization, which can race with concurrent mode updates and lead to inconsistent Anti‑Lag behavior or undefined read/write races.
- Ensure `frame_markers.present` is read with the proper acquire semantics to pair with the existing release store, preserving the intended happens‑before relationship for timeline/frame indexing.

### Description
- In `d3d12_amd_ext_anti_lag_UpdateAntiLagState()` take a snapshot of `swapchain_info.mode` and `swapchain_info.max_fps` while holding `low_latency_swapchain_spinlock` and use that local snapshot (`mode`, `max_fps`) for building `VkAntiLagDataAMD` and gating timeline trace calls.
- Replace the direct read of `device->frame_markers.present` with `vkd3d_atomic_uint64_load_explicit(&device->frame_markers.present, vkd3d_memory_order_acquire)` and increment the returned value into a local `frame_index` before storing it back with the existing release store.

### Testing
- Applied the patch to `packages/vkd3d-proton-mingw-git/patches/device_vkd3d_ext.c` and inspected the modified region with `rg`, `sed`, and `nl` to verify the new lock/atomic usage and balanced lock/unlock pairs.
- Performed a focused static review of the modified function to confirm the acquire load pairs with the existing `vkd3d_atomic_uint64_store_explicit(..., vkd3d_memory_order_release)` and that the snapshot variable is consistently used for subsequent calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5d13c7f8832aa1df11127c6ec4de)