### PR TITLE
Fix PHI incoming values when unfolding selects in DFAJumpThreading

### DIFF
--- a/llvm-raptorlake-experiments/DFAJumpThreading.cpp.fail1
+++ b/llvm-raptorlake-experiments/DFAJumpThreading.cpp.fail1
@@ -266,9 +266,11 @@ void DFAJumpThreading::unfold(
           Twine(SI->getName(), ".si.unfold.phi"),
           EndBlock->getFirstInsertionPt());
 
-      for (BasicBlock *Pred : predecessors(EndBlock)) {
-        if (Pred != StartBlock && Pred != NewBlock)
-          EndPhi->addIncoming(EndPhi, Pred);
+      for (unsigned I = 0, E = SIUse->getNumIncomingValues(); I != E; ++I) {
+        BasicBlock *Pred = SIUse->getIncomingBlock(I);
+        if (Pred == StartBlock)
+          continue;
+        EndPhi->addIncoming(SIUse->getIncomingValue(I), Pred);
       }
 
       EndPhi->addIncoming(SIOp1, StartBlock);


### PR DESCRIPTION
### Motivation
- Prevent incorrectly constructing a self-referential `PHINode` when unfolding a `SelectInst` by ensuring the new `EndPhi` receives the correct incoming values and blocks instead of adding itself as an incoming value.

### Description
- Replace iterating over `predecessors(EndBlock)` with iterating the incoming entries of `SIUse` using `SIUse->getNumIncomingValues()`, `SIUse->getIncomingBlock(I)`, and `SIUse->getIncomingValue(I)` to copy the correct incoming values into `EndPhi` while skipping `StartBlock`.
- Add the `StartBlock` and `NewBlock` incoming values explicitly with `SIOp1` and `NewPhi` respectively, and stop adding `EndPhi` as an incoming value.

### Testing
- Built the project with `ninja` and ran the relevant LLVM unit tests exercised by `llvm-lit` for jump-threading and PHI handling, and the tests covering this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc8cdfc8c832aa21398c1c7d6b46d)