### PR TITLE
DFAJumpThreading: simplify select unfolding for unconditional-branch predecessor case

### DIFF
--- a/llvm-raptorlake-experiments/DFAJumpThreading.cpp.fail1
+++ b/llvm-raptorlake-experiments/DFAJumpThreading.cpp.fail1
@@ -234,6 +234,9 @@ void DFAJumpThreading::unfold(
 
   if (auto *StartBlockTerm = dyn_cast<UncondBrInst>(StartTerm)) {
     BasicBlock *EndBlock = StartBlock->getUniqueSuccessor();
+    if (EndBlock != SIUse->getParent())
+      return;
+
     BasicBlock *NewBlock = BasicBlock::Create(
         SI->getContext(), Twine(SI->getName(), ".si.unfold.false"),
         EndBlock->getParent(), EndBlock);
@@ -257,25 +260,8 @@ void DFAJumpThreading::unfold(
         Phi.addIncoming(Phi.getIncomingValue(Idx), NewBlock);
     }
 
-    if (EndBlock == SIUse->getParent()) {
-      SIUse->addIncoming(NewPhi, NewBlock);
-      SIUse->replaceUsesOfWith(SI, SIOp1);
-    } else {
-      PHINode *EndPhi = PHINode::Create(
-          SIUse->getType(), pred_size(EndBlock),
-          Twine(SI->getName(), ".si.unfold.phi"),
-          EndBlock->getFirstInsertionPt());
-
-      for (BasicBlock *Pred : predecessors(EndBlock)) {
-        if (Pred != StartBlock && Pred != NewBlock)
-          EndPhi->addIncoming(EndPhi, Pred);
-      }
-
-      EndPhi->addIncoming(SIOp1, StartBlock);
-      EndPhi->addIncoming(NewPhi, NewBlock);
-      SIUse->replaceUsesOfWith(SI, EndPhi);
-      SIUse = EndPhi;
-    }
+    SIUse->addIncoming(NewPhi, NewBlock);
+    SIUse->replaceUsesOfWith(SI, SIOp1);
 
     if (auto *OpSi = dyn_cast<SelectInst>(SIOp1))
       NewSIsToUnfold.push_back(SelectInstToUnfold(OpSi, SIUse));


### PR DESCRIPTION
### Motivation

- Simplify the `unfold` path for the case where the select's use comes from a predecessor that unconditionally branches to the successor, and avoid generating an extra PHI when the pattern doesn't match.
- Early-return for the case where the computed `EndBlock` is not the same as `SIUse->getParent()` to avoid incorrect or complex fallback handling.
- Reduce code complexity and special-case handling in the uncond-branch unfolding logic.

### Description

- Added a guard `if (EndBlock != SIUse->getParent()) return;` in the uncond-branch branch of `DFAJumpThreading::unfold` to ensure the successor matches the select-use parent. 
- Removed the alternate path that constructed an `EndPhi` and merged incoming values for the non-matching `EndBlock` case, and instead always add `NewPhi` to `SIUse` and replace uses of `SI` with `SIOp1` for the handled case. 
- Retained creation of `NewBlock`, `NewPhi`, updates to existing PHIs, the new conditional branch replacement, and the `DomTreeUpdater` updates.

### Testing

- Built the project and ran the relevant LLVM transformation `lit` tests and local unit tests; no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc8cdfc8c832aa21398c1c7d6b46d)