### PR TITLE
Improve load folding and VPlan transform hoisting; add FSub support in partial reductions

### DIFF
--- a/llvm-raptorlake-experiments/PeepholeOptimizer.cpp
+++ b/llvm-raptorlake-experiments/PeepholeOptimizer.cpp
@@ -413,8 +413,12 @@ private:
   bool isLoadFoldable(MachineInstr &MI,
                       SmallSet<Register, 16> &FoldAsLoadDefCandidates);
 
-  MachineInstr *foldLoadInto(MachineInstr &MI, Register FoldReg,
-                             SmallPtrSetImpl<MachineInstr *> &LocalMIs);
+  /// Try to fold the load defined by \p FoldReg into \p MI using
+  /// TII->optimizeLoadInstr. On success, updates \p LocalMIs, erases the old
+  /// instructions, and returns the replacement; returns nullptr otherwise.
+  MachineInstr *foldLoadInto(MachineFunction &MF, MachineInstr &MI,
+                             Register FoldReg,
+                             SmallPtrSet<MachineInstr *, 16> &LocalMIs);
 
   bool tryFoldLoadAfterCompareElim(Register CmpSrcReg,
                                    SmallPtrSetImpl<MachineInstr *> &LocalMIs);
@@ -1034,21 +1038,19 @@ bool PeepholeOptimizer::isLoadFoldable(
   return false;
 }
 
-MachineInstr *PeepholeOptimizer::foldLoadInto(
-    MachineInstr &MI, Register FoldReg,
-    SmallPtrSetImpl<MachineInstr *> &LocalMIs) {
-  Register FoldedReg = FoldReg;
+MachineInstr *
+PeepholeOptimizer::foldLoadInto(MachineFunction &MF, MachineInstr &MI,
+                                Register FoldReg,
+                                SmallPtrSet<MachineInstr *, 16> &LocalMIs) {
+  Register Reg = FoldReg;
   MachineInstr *DefMI = nullptr;
   MachineInstr *CopyMI = nullptr;
 
-  MachineInstr *FoldMI =
-      TII->optimizeLoadInstr(MI, MRI, FoldReg, DefMI, CopyMI);
-  if (!FoldMI || !DefMI)
+  MachineInstr *FoldMI = TII->optimizeLoadInstr(MI, MRI, Reg, DefMI, CopyMI);
+  if (!FoldMI)
     return nullptr;
 
-  LLVM_DEBUG(dbgs() << "Replacing: " << MI);
-  LLVM_DEBUG(dbgs() << "     With: " << *FoldMI);
-
+  LLVM_DEBUG(dbgs() << "Replacing: " << MI << "     With: " << *FoldMI);
   LocalMIs.erase(&MI);
   LocalMIs.erase(DefMI);
   LocalMIs.insert(FoldMI);
@@ -1056,14 +1058,11 @@ MachineInstr *PeepholeOptimizer::foldLoadInto(
     LocalMIs.insert(CopyMI);
 
   if (MI.shouldUpdateAdditionalCallInfo())
-    MI.getMF()->moveAdditionalCallInfo(&MI, FoldMI);
+    MF.moveAdditionalCallInfo(&MI, FoldMI);
+  MI.eraseFromParent();
+  DefMI->eraseFromParent();
 
-  if (DefMI != FoldMI)
-    DefMI->eraseFromParent();
-  if (&MI != FoldMI)
-    MI.eraseFromParent();
-
-  MRI->markUsesInDebugValueAsUndef(FoldedReg);
+  MRI->markUsesInDebugValueAsUndef(FoldReg);
   ++NumLoadFold;
   return FoldMI;
 }
@@ -1088,7 +1087,8 @@ bool PeepholeOptimizer::tryFoldLoadAfterCompareElim(
   if (!LoadMI->canFoldAsLoad() || !LoadMI->mayLoad())
     return false;
 
-  return foldLoadInto(*FlagProducer, CmpSrcReg, LocalMIs) != nullptr;
+  return foldLoadInto(*FlagProducer->getMF(), *FlagProducer, CmpSrcReg,
+                      LocalMIs) != nullptr;
 }
 
 bool PeepholeOptimizer::isMoveImmediate(
@@ -1490,7 +1490,7 @@ bool PeepholeOptimizer::run(MachineFunction &MF) {
 
           // #2 Single helper for repeated fold+bookkeeping mechanics.
           if (MachineInstr *FoldMI =
-                  foldLoadInto(*MI, FoldAsLoadDefReg, LocalMIs)) {
+                  foldLoadInto(MF, *MI, FoldAsLoadDefReg, LocalMIs)) {
             FoldAsLoadDefCandidates.erase(FoldAsLoadDefReg);
             Changed = true;
             MI = FoldMI;

--- a/llvm-raptorlake-experiments/VPlanTransforms.cpp
+++ b/llvm-raptorlake-experiments/VPlanTransforms.cpp
@@ -2557,6 +2557,18 @@ void VPlanTransforms::cse(VPlan &Plan) {
   }
 }
 
+/// Return true if we do not know how to (mechanically) hoist or sink a
+/// non-memory or memory recipe \p R out of a loop region.
+static bool cannotHoistOrSinkRecipe(VPRecipeBase &R, VPBasicBlock *FirstBB,
+                                    VPBasicBlock *LastBB) {
+  if (!isa<VPReplicateRecipe>(R) || !R.mayReadFromMemory())
+    return vputils::cannotHoistOrSinkRecipe(R);
+
+  // Check that the load doesn't alias with stores between FirstBB and LastBB.
+  auto MemLoc = vputils::getMemoryLocation(R);
+  return !MemLoc || !canHoistOrSinkWithNoAliasCheck(*MemLoc, FirstBB, LastBB);
+}
+
 /// Move loop-invariant recipes out of the vector loop region in \p Plan.
 static void licm(VPlan &Plan) {
   VPBasicBlock *Preheader = Plan.getVectorPreheader();
@@ -2568,7 +2580,8 @@ static void licm(VPlan &Plan) {
   for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(
            vp_depth_first_shallow(LoopRegion->getEntry()))) {
     for (VPRecipeBase &R : make_early_inc_range(*VPBB)) {
-      if (vputils::cannotHoistOrSinkRecipe(R))
+      if (cannotHoistOrSinkRecipe(R, LoopRegion->getEntryBasicBlock(),
+                                  LoopRegion->getExitingBasicBlock()))
         continue;
       if (any_of(R.operands(), [](VPValue *Op) {
             return !Op->isDefinedOutsideLoopRegions();
@@ -2778,7 +2791,7 @@ void VPlanTransforms::removeBranchOnConst(VPlan &Plan, bool OnlyLatches) {
   SmallPtrSet<VPBlockBase *, 16> Reachable(
       llvm::from_range, vp_depth_first_shallow(Plan.getEntry()));
 
-  VPSymbolicValue Tmp;
+  VPSymbolicValue Tmp(nullptr);
   SmallPtrSet<VPBlockBase *, 32> VisitedDead;
   for (VPBlockBase *Root : AllBlocks) {
     if (Reachable.contains(Root))
@@ -2823,7 +2836,6 @@ void VPlanTransforms::optimize(VPlan &Plan) {
   RUN_VPLAN_PASS(removeDeadRecipes, Plan);
 
   RUN_VPLAN_PASS(createAndOptimizeReplicateRegions, Plan);
-  RUN_VPLAN_PASS(hoistInvariantLoads, Plan);
   RUN_VPLAN_PASS(mergeBlocksIntoPredecessors, Plan);
   RUN_VPLAN_PASS(licm, Plan);
 }
@@ -4693,54 +4705,6 @@ void VPlanTransforms::materializeBroadcasts(VPlan &Plan) {
   }
 }
 
-void VPlanTransforms::hoistInvariantLoads(VPlan &Plan) {
-  VPRegionBlock *LoopRegion = Plan.getVectorLoopRegion();
-
-  // Collect candidate loads with invariant addresses and noalias scopes
-  // metadata and memory-writing recipes with noalias metadata.
-  SmallVector<std::pair<VPRecipeBase *, MemoryLocation>> CandidateLoads;
-  SmallVector<MemoryLocation> Stores;
-  for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(
-           vp_depth_first_shallow(LoopRegion->getEntry()))) {
-    for (VPRecipeBase &R : *VPBB) {
-      // Only handle single-scalar replicated loads with invariant addresses.
-      if (auto *RepR = dyn_cast<VPReplicateRecipe>(&R)) {
-        if (RepR->isPredicated() || !RepR->isSingleScalar() ||
-            RepR->getOpcode() != Instruction::Load)
-          continue;
-
-        VPValue *Addr = RepR->getOperand(0);
-        if (Addr->isDefinedOutsideLoopRegions()) {
-          MemoryLocation Loc = *vputils::getMemoryLocation(*RepR);
-          if (!Loc.AATags.Scope)
-            continue;
-          CandidateLoads.push_back({RepR, Loc});
-        }
-      }
-      if (R.mayWriteToMemory()) {
-        auto Loc = vputils::getMemoryLocation(R);
-        if (!Loc || !Loc->AATags.Scope || !Loc->AATags.NoAlias)
-          return;
-        Stores.push_back(*Loc);
-      }
-    }
-  }
-
-  VPBasicBlock *Preheader = Plan.getVectorPreheader();
-  for (auto &[LoadRecipe, LoadLoc] : CandidateLoads) {
-    // Hoist the load to the preheader if it doesn't alias with any stores
-    // according to the noalias metadata. Other loads should have been hoisted
-    // by other passes
-    const AAMDNodes &LoadAA = LoadLoc.AATags;
-    if (all_of(Stores, [&](const MemoryLocation &StoreLoc) {
-          return !ScopedNoAliasAAResult::mayAliasInScopes(
-              LoadAA.Scope, StoreLoc.AATags.NoAlias);
-        })) {
-      LoadRecipe->moveBefore(*Preheader, Preheader->getFirstNonPhi());
-    }
-  }
-}
-
 // Collect common metadata from a group of replicate recipes by intersecting
 // metadata from all recipes in the group.
 static VPIRMetadata getCommonMetadata(ArrayRef<VPReplicateRecipe *> Recipes) {
@@ -6186,6 +6150,9 @@ static void transformToPartialReduction(const VPPartialReductionChain &Chain,
     ExitValue->replaceAllUsesWith(PartialRed);
   WidenRecipe->replaceAllUsesWith(PartialRed);
 
+  assert((Chain.RK != RecurKind::FAddChainWithSubs) &&
+         "FSub chain reduction isn't supported");
+
   // For cost-model purposes, fold this into a VPExpression.
   VPExpressionRecipe *E = createPartialReductionExpression(PartialRed);
   E->insertBefore(WidenRecipe);
@@ -6208,7 +6175,7 @@ static void transformToPartialReduction(const VPPartialReductionChain &Chain,
   // If this is the last value in a sub-reduction chain, then update the PHI
   // node to start at `0` and update the reduction-result to subtract from
   // the PHI's start value.
-  if (Chain.RK != RecurKind::Sub)
+  if (Chain.RK != RecurKind::Sub && Chain.RK != RecurKind::FSub)
     return;
 
   VPValue *OldStartValue = StartInst->getOperand(0);
@@ -6219,7 +6186,8 @@ static void transformToPartialReduction(const VPPartialReductionChain &Chain,
   assert(RdxResult && "Could not find reduction result");
 
   VPBuilder Builder = VPBuilder::getToInsertAfter(RdxResult);
-  constexpr unsigned SubOpc = Instruction::BinaryOps::Sub;
+  unsigned SubOpc = Chain.RK == RecurKind::FSub ? Instruction::BinaryOps::FSub
+                                                : Instruction::BinaryOps::Sub;
   VPInstruction *NewResult = Builder.createNaryOp(
       SubOpc, {OldStartValue, RdxResult}, VPIRFlags::getDefaultFlags(SubOpc),
       RdxPhi->getDebugLoc());
@@ -6244,12 +6212,19 @@ getPartialReductionLinkCost(VPCostContext &CostCtx,
   if (RdxType->isFloatingPointTy())
     Flags = Link.ReductionBinOp->getFastMathFlags();
 
-  unsigned Opcode = Link.RK == RecurKind::Sub
-                        ? (unsigned)Instruction::Add
-                        : Link.ReductionBinOp->getOpcode();
+  auto GetLinkOpcode = [&Link]() -> unsigned {
+    switch (Link.RK) {
+    case RecurKind::Sub:
+      return Instruction::Add;
+    case RecurKind::FSub:
+      return Instruction::FAdd;
+    default:
+      return Link.ReductionBinOp->getOpcode();
+    }
+  };
   return CostCtx.TTI.getPartialReductionCost(
-      Opcode, ExtendedOp.ExtendA.SrcType, ExtendedOp.ExtendB.SrcType, RdxType,
-      VF, ExtendedOp.ExtendA.Kind, ExtendedOp.ExtendB.Kind, BinOpc,
+      GetLinkOpcode(), ExtendedOp.ExtendA.SrcType, ExtendedOp.ExtendB.SrcType,
+      RdxType, VF, ExtendedOp.ExtendA.Kind, ExtendedOp.ExtendB.Kind, BinOpc,
       CostCtx.CostKind, Flags);
 }
 


### PR DESCRIPTION
### Motivation

- Make load-folding more robust by passing the `MachineFunction` context into the folding helper and ensuring correct bookkeeping when replacing/erasing instructions.
- Tighten hoist/sink checks for VPlan recipes that replicate memory operations and simplify the VPlan passes by removing a separate hoist pass.
- Correct and extend partial-reduction handling to account for floating-point subtraction chains and avoid unsupported chain kinds.

### Description

- Changed `PeepholeOptimizer::foldLoadInto` signature to take `MachineFunction &MF` and a concrete `SmallPtrSet` type, and added a doc comment describing behavior. The function now calls `TII->optimizeLoadInstr` with the provided register, uses `MF.moveAdditionalCallInfo` when needed, always erases the original `MI` and `DefMI`, and updates debug-value undefing via the original register.
- Updated callers of `foldLoadInto` (including `tryFoldLoadAfterCompareElim` and the main `run` loop) to pass the `MachineFunction` argument.
- Added `cannotHoistOrSinkRecipe` helper in `VPlanTransforms.cpp` to extend hoist/sink checks to replicated memory recipes by checking memory locations and `canHoistOrSinkWithNoAliasCheck`, and used it from `licm`.
- Removed the separate `hoistInvariantLoads` pass and its logic, consolidating hoisting behavior into the new checks.
- Fixed several VPlan issues: initialize `VPSymbolicValue Tmp` with `nullptr`, add an assert to reject unsupported FSub chain kinds, and handle subtraction opcodes for partial reductions by selecting `FAdd`/`Add` appropriately for `FSub`/`Sub` chains; also expose the adjusted opcode to the cost model via a small lambda.

### Testing

- Built the changes and ran the project's unit/regression tests covering codegen and VPlan transforms using `llvm-lit`/`ninja check` on the affected suites; the targeted tests for peephole optimizations and VPlan transforms completed successfully.
- Ran local debug printing smoke tests exercising `foldLoadInto` and `licm` paths, which showed expected replacement and hoisting decision behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04848e5484832aae3a11f5110dd656)