### PR TITLE
Configurable float mul-add fusion: add ffma_weak, fmad/fmadz support and refactor FFMA rules

### DIFF
--- a/vega-experiments/nir_opt_algebraic.py
+++ b/vega-experiments/nir_opt_algebraic.py
@@ -32,7 +32,7 @@ def lowered_sincos(c):
     """
     x = ('fsub', ('fmul', 2.0, ('ffract', ('fadd', ('fmul', 0.5 / pi, a), c))), 1.0)
     x = ('fmul', ('fsub', x, ('fmul', x, ('fabs', x))), 4.0)
-    return ('ffma', ('ffma', x, ('fabs', x), ('fneg', x)), 0.225, x)
+    return ('ffma_weak', ('ffma_weak', x, ('fabs', x), ('fneg', x)), 0.225, x)
 
 
 def intBitsToFloat(i):
@@ -178,14 +178,6 @@ optimizations += [
 
     (('~fadd', ('fmul', a, b), ('fmul', a, c)), ('fmul', a, ('fadd', b, c))),
     (('~fadd', ('fmulz', a, b), ('fmulz', a, c)), ('fmulz', a, ('fadd', b, c))),
-    (('~ffma', a, b, ('ffma(is_used_once)', a, c, d)), ('ffma', a, ('fadd', b, c), d)),
-    (('~ffma', a, b, ('fmul(is_used_once)', a, c)), ('fmul', a, ('fadd', b, c))),
-    (('~fadd', ('fmul(is_used_once)', a, b), ('ffma(is_used_once)', a, c, d)), ('ffma', a, ('fadd', b, c), d)),
-    (('~ffma', a, ('fmul(is_used_once)', b, c), ('fmul(is_used_once)', b, d)), ('fmul', b, ('ffma', a, c, d))),
-    (('~ffmaz', a, b, ('ffmaz(is_used_once)', a, c, d)), ('ffmaz', a, ('fadd', b, c), d)),
-    (('~ffmaz', a, b, ('fmulz(is_used_once)', a, c)), ('fmulz', a, ('fadd', b, c))),
-    (('~fadd', ('fmulz(is_used_once)', a, b), ('ffmaz(is_used_once)', a, c, d)), ('ffmaz', a, ('fadd', b, c), d)),
-    (('~ffmaz', a, ('fmulz(is_used_once)', b, c), ('fmulz(is_used_once)', b, d)), ('fmulz', b, ('ffmaz', a, c, d))),
 
     (('iadd', ('imul', a, b), ('imul', a, c)), ('imul', a, ('iadd', b, c))),
     (('iadd', ('ishl', b, a), ('ishl', c, a)), ('ishl', ('iadd', b, c), a)),
@@ -256,8 +248,6 @@ optimizations += [
     (('ffmaz(nsz)', 1.0, a, b), ('fadd', a, b)),
     (('ffma', -1.0, a, b), ('fadd', ('fneg', a), b)),
     (('ffmaz(nsz)', -1.0, a, b), ('fadd', ('fneg', a), b)),
-    (('~ffma', '#a', '#b', c), ('fadd', ('fmul', a, b), c)),
-    (('~ffmaz', '#a', '#b', c), ('fadd', ('fmulz', a, b), c)),
 
     (('flrp(nnan,nsz)', a, b, 0.0), ('fcanonicalize', a)),
     (('flrp(nnan,nsz)', a, b, -0.0), ('fcanonicalize', a)),
@@ -337,6 +327,24 @@ optimizations += [
      ('fexp2', ('fmulz', a, 'mb'))), {'mb': b}),
 ]
 
+# float multadd related rules
+for sz in (16, 32, 64):
+    has_ffma = f'(options->float_mul_add{sz} & nir_float_muladd_support_has_ffma)'
+    has_fmad = f'(options->float_mul_add{sz} & nir_float_muladd_support_has_fmad)'
+    has_none = f'(!options->float_mul_add{sz})'
+    prefers_split = f'(options->float_mul_add{sz} & nir_float_muladd_support_prefers_split)'
+    keep_ffma_weak = f'(options->float_mul_add{sz} & nir_float_muladd_support_keep_weak_ffma)'
+    optimizations += [
+        ((f'ffma_weak@{sz}(contract)', a, b, c), ('fadd', ('fmul', a, b), c), f'!{keep_ffma_weak}'),
+        ((f'ffma_weak@{sz}', a, b, c), ('ffma', a, b, c), f'!{keep_ffma_weak} && !{prefers_split} && {has_ffma}'),
+        ((f'ffma_weak@{sz}', a, b, c), ('fadd', ('fmul', a, b), c), f'!{keep_ffma_weak} && ({prefers_split} || {has_fmad} || {has_none})'),
+    ]
+
+optimizations += [
+    (('fmad', a, b, c), ('fadd', ('fmul', a, b), c)),
+    (('fmadz', a, b, c), ('fadd', ('fmulz', a, b), c)),
+]
+
 for sz in (16, 32, 64):
     sign_bit = 1 << (sz - 1)
     optimizations.extend([
@@ -394,11 +402,7 @@ optimizations.extend([
     (('~fadd', ('fmul', a, ('b2f', ('inot', 'c@1'))), ('fmul', b, ('b2f',  c))), ('bcsel', c, ('fcanonicalize', b), ('fcanonicalize', a))),
     (('~fadd', a, ('fmul', ('b2f', 'c@1'), ('fadd', b, ('fneg', a)))), ('bcsel', c, ('fcanonicalize', b), ('fcanonicalize', a))),
 
-    (('~ffma', a, ('b2f', ('inot', 'c@1')), ('fmul', b, ('b2f', 'c@1'))), ('bcsel', c, ('fcanonicalize', b), ('fcanonicalize', a))),
-    (('~ffma', b, ('b2f', 'c@1'), ('ffma', ('fneg', a), ('b2f', 'c@1'), a)), ('bcsel', c, ('fcanonicalize', b), ('fcanonicalize', a))),
 
-    (('~ffma', ('b2f', 'c@1'), ('fadd', b, ('fneg', a)), a), ('bcsel', c, ('fcanonicalize', b), ('fcanonicalize', a))),
-    (('~ffma', ('b2f', 'c@1'), ('ffma', ('fneg', a), b, d), ('fmul', a, b)), ('bcsel', c, ('fcanonicalize', d), ('fmul', a, b))),
 
     (('~flrp', ('fmul(is_used_once)', a, b), ('fmul(is_used_once)', a, c), d), ('fmul', ('flrp', b, c, d), a)),
     (('~flrp', a, 0.0, c), ('fadd', ('fmul', ('fneg', a), c), a)),
@@ -432,14 +436,6 @@ optimizations.extend([
     (('fadd@64', a, ('fneg(is_used_once)', ('ffloor(is_used_once)', a))), ('ffract', a), '!options->lower_ffract && !(options->lower_doubles_options & nir_lower_dfract)'),
     (('fceil', a), ('fneg', ('ffloor', ('fneg', a))), 'options->lower_fceil'),
 
-    (('ffma@16', a, b, c), ('fadd', ('fmul', a, b), c), 'options->lower_ffma16'),
-    (('ffma@32', a, b, c), ('fadd', ('fmul', a, b), c), 'options->lower_ffma32'),
-    (('ffma@64', a, b, c), ('fadd', ('fmul', a, b), c), 'options->lower_ffma64'),
-    (('ffmaz', a, b, c), ('fadd', ('fmulz', a, b), c), 'options->lower_ffma32'),
-    (('ffma@16(contract)', a, b, c), ('fadd', ('fmul', a, b), c), 'options->fuse_ffma16'),
-    (('ffma@32(contract)', a, b, c), ('fadd', ('fmul', a, b), c), 'options->fuse_ffma32'),
-    (('ffma@64(contract)', a, b, c), ('fadd', ('fmul', a, b), c), 'options->fuse_ffma64'),
-    (('ffmaz(contract)', a, b, c), ('fadd', ('fmulz', a, b), c), 'options->fuse_ffma32'),
 
     (('fmul', ('fadd', ('bcsel', a, ('fmul', b, c), 0), '#d'), '#e'),
      ('bcsel', a, ('fmul', ('fadd', ('fmul', b, c), d), e), ('fmul', ('fadd', d, 0.0), e))),
@@ -2257,23 +2253,14 @@ optimizations.extend([
 
    (('~fadd', ('fadd(is_used_once)', 'a(is_not_const)', 'b(is_fmul)'), '#c'), ('fadd', ('fadd', a, c), b)),
    (('~fadd', ('fadd(is_used_once)', 'a(is_not_const)', 'b(is_not_const)'), '#c'), ('fadd', ('fadd', a, c), b)),
-   (('~fadd', ('ffma(is_used_once)', 'a(is_not_const)', b, 'c(is_not_const)'), '#d'), ('fadd', ('ffma', a, b, d), c)),
-   (('~fadd', ('ffmaz(is_used_once)', 'a(is_not_const)', b, 'c(is_not_const)'), '#d'), ('fadd', ('ffmaz', a, b, d), c)),
    (('iadd', ('iadd(is_used_once)', 'a(is_not_const)', 'b(is_not_const)'), '#c'), ('iadd', ('iadd', a, c), b)),
 
    (('~fmul', '#a', ('fmul', b, '#c')), ('fmul', ('fmul', a, c), b)),
    (('~fmulz', '#a', ('fmulz', b, '#c')), ('fmulz', ('fmulz', a, c), b)),
    (('~fmul', '#a(is_finite_not_zero)', ('fmulz', b, '#c')), ('fmulz', ('fmul', a, c), b)),
-   (('~ffma', '#a', ('fmul', b, '#c'), d), ('ffma', ('fmul', a, c), b, d)),
-   (('~ffmaz', '#a', ('fmulz', b, '#c'), d), ('ffmaz', ('fmulz', a, c), b, d)),
-   (('~ffmaz', '#a(is_finite_not_zero)', ('fmulz', b, '#c'), d), ('ffmaz', ('fmul', a, c), b, d)),
    (('imul', '#a', ('imul', b, '#c')), ('imul', ('imul', a, c), b)),
    (('~fadd', '#a',          ('fadd', b, '#c')),  ('fadd', ('fadd', a,          c),           b)),
    (('~fadd', '#a', ('fneg', ('fadd', b, '#c'))), ('fadd', ('fadd', a, ('fneg', c)), ('fneg', b))),
-   (('~fadd', '#a',          ('ffma', b, c, '#d')),  ('ffma',          b,  c, ('fadd', a,          d))),
-   (('~fadd', '#a', ('fneg', ('ffma', b, c, '#d'))), ('ffma', ('fneg', b), c, ('fadd', a, ('fneg', d)))),
-   (('~fadd', '#a',          ('ffmaz', b, c, '#d')),  ('ffmaz',          b,  c, ('fadd', a,          d))),
-   (('~fadd', '#a', ('fneg', ('ffmaz', b, c, '#d'))), ('ffmaz', ('fneg', b), c, ('fadd', a, ('fneg', d)))),
    (('iadd', '#a', ('iadd', b, '#c')), ('iadd', ('iadd', a, c), b)),
    (('iand', '#a', ('iand', b, '#c')), ('iand', ('iand', a, c), b)),
    (('ior',  '#a', ('ior',  b, '#c')), ('ior',  ('ior',  a, c), b)),
@@ -3626,52 +3613,41 @@ late_optimizations.extend([
      ('fmul', ('vec2', a, b), ('vec2', -1.0, 1.0)), 'options->vectorize_vec2_16bit'),
     (('vec2(is_only_used_as_float)', a, ('fneg@16', b)),
      ('fmul', ('vec2', a, b), ('vec2', 1.0, -1.0)), 'options->vectorize_vec2_16bit'),
+])
 
-    (('fadd@32', ('fmul@32(is_used_once)', 'a@32', 'b@32'), 'c@32'),
-     ('ffma@32', 'a', 'b', 'c'), 'options->fuse_ffma32'),
-    (('fadd@16', ('fmul@16(is_used_once)', 'a@16', 'b@16'), 'c@16'),
-     ('ffma@16', 'a', 'b', 'c'), 'options->fuse_ffma16'),
 
-    (('~fadd@32', ('fmul@32(is_used_once)', 'a@32', 'b@32'), 'c@32'),
-     ('ffma@32', 'a', 'b', 'c'), 'options->fuse_ffma32'),
-    (('~fadd@16', ('fmul@16(is_used_once)', 'a@16', 'b@16'), 'c@16'),
-     ('ffma@16', 'a', 'b', 'c'), 'options->fuse_ffma16'),
+for sz, mulz in itertools.product([16, 32, 64], [False, True]):
+    fmul = ('fmulz' if mulz else 'fmul') + f'@{sz}(is_only_used_by_fadd)'
 
-    (('fadd@32', ('fmulz@32(is_used_once)', 'a@32', 'b@32'), 'c@32'),
-     ('ffmaz@32', 'a', 'b', 'c'), 'options->fuse_ffma32 && ' + has_fmulz),
-    (('~fadd@32', ('fmulz@32(is_used_once)', 'a@32', 'b@32'), 'c@32'),
-     ('ffmaz@32', 'a', 'b', 'c'), 'options->fuse_ffma32 && ' + has_fmulz),
+    option = f'options->float_mul_add{sz}'
+    option_avoid_abs = 'options->avoid_ternary_with_fabs'
+    option_has_fmad = f'({option} & nir_float_muladd_support_has_fmad)'
+    option_has_ffma = f'({option} & nir_float_muladd_support_has_ffma)'
+    option_prefer_split = f'({option} & nir_float_muladd_support_prefers_split)'
+    option_fuse = f'({option} & nir_float_muladd_support_fuse)'
 
-    (('fadd@32', 'c@32', ('fmul@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffma@32', 'a', 'b', 'c'),
-     'options->fuse_ffma32'),
+    option_fmad = f'{option_fuse} && (!{option_has_ffma} ||  {option_prefer_split}) && {option_has_fmad}'
+    option_ffma = f'{option_fuse} && (!{option_has_fmad} || !{option_prefer_split}) && {option_has_ffma}'
 
-    (('fadd@16', 'c@16', ('fmul@16(is_used_once)', 'a@16', 'b@16')),
-     ('ffma@16', 'a', 'b', 'c'),
-     'options->fuse_ffma16'),
+    for fmad in ['ffma', 'fmad']:
+        option = option_fmad if fmad == 'fmad' else option_ffma
+        fadd = f'fadd@{sz}' if fmad == 'fmad' else f'fadd@{sz}(contract)'
+        fmad = (fmad + 'z' if mulz else fmad) + f'@{sz}'
 
-    (('fadd@32', 'c@32', ('fmulz@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffmaz@32', 'a', 'b', 'c'),
-     'options->fuse_ffma32 && ' + has_fmulz),
+        late_optimizations.extend([
+            ((fadd, (fmul, a, b), c), (fmad, a, b, c), option),
 
-    (('fsub@32', 'c@32', ('fmul@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffma@32', ('fneg', 'a'), 'b', 'c'), 'options->fuse_ffma32'),
-    (('~fsub@32', 'c@32', ('fmul@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffma@32', ('fneg', 'a'), 'b', 'c'), 'options->fuse_ffma32'),
+            ((fadd, ('fneg(is_only_used_by_fadd)', (fmul, a, b)), c),
+             (fmad, ('fneg', a), b, c), option),
 
-    (('fsub@32', 'c@32', ('fmulz@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffmaz@32', ('fneg', 'a'), 'b', 'c'), 'options->fuse_ffma32 && ' + has_fmulz),
-    (('~fsub@32', 'c@32', ('fmulz@32(is_used_once)', 'a@32', 'b@32')),
-     ('ffmaz@32', ('fneg', 'a'), 'b', 'c'), 'options->fuse_ffma32 && ' + has_fmulz),
+            ((fadd, ('fabs(is_only_used_by_fadd)', (fmul, a, b)), c),
+             (fmad, ('fabs', a), ('fabs', b), c), f'{option} && !{option_avoid_abs}'),
 
-    (('fsub@16', 'c@16', ('fmul@16(is_used_once)', 'a@16', 'b@16')),
-     ('ffma@16', ('fneg', 'a'), 'b', 'c'),
-     'options->fuse_ffma16'),
+            ((fadd, ('fneg(is_only_used_by_fadd)', ('fabs', (fmul, a, b))), c),
+             (fmad, ('fneg', ('fabs', a)), ('fabs', b), c), f'{option} && !{option_avoid_abs}'),
+        ])
 
-    (('~fsub@16', 'c@16', ('fmul@16(is_used_once)', 'a@16', 'b@16')),
-     ('ffma@16', ('fneg', 'a'), 'b', 'c'),
-     'options->fuse_ffma16'),
-
+late_optimizations.extend([
     (('flt', '#b(is_a_number_gt_0_and_lt_1)', ('fsat(is_used_once)', a)), ('flt', b, a)),
     (('fge', ('fsat(is_used_once)', a), '#b(is_a_number_gt_0_and_lt_1)'), ('fge', a, b)),
     (('feq', ('fsat(is_used_once)', a), '#b(is_a_number_gt_0_and_lt_1)'), ('feq', a, b)),
@@ -3716,6 +3692,10 @@ late_optimizations.extend([
     (('~ffma@32', a, -2.0, -1.0), ('flrp', -1.0, 1.0, ('fneg', a)), '!options->lower_flrp32'),
     (('~ffma@32', a, -2.0, 1.0), ('flrp', 1.0, -1.0, a), '!options->lower_flrp32'),
     (('~ffma@32', a, 2.0, 1.0), ('flrp', 1.0, -1.0, ('fneg', a)), '!options->lower_flrp32'),
+    (('~fmad@32', a, 2.0, -1.0), ('flrp', -1.0, 1.0, a), '!options->lower_flrp32'),
+    (('~fmad@32', a, -2.0, -1.0), ('flrp', -1.0, 1.0, ('fneg', a)), '!options->lower_flrp32'),
+    (('~fmad@32', a, -2.0, 1.0), ('flrp', 1.0, -1.0, a), '!options->lower_flrp32'),
+    (('~fmad@32', a, 2.0, 1.0), ('flrp', 1.0, -1.0, ('fneg', a)), '!options->lower_flrp32'),
 
     (('~fadd@32', ('fmul(is_used_once)', 2.0, a), -1.0), ('flrp', -1.0, 1.0, a), '!options->lower_flrp32'),
     (('~fadd@32', ('fmul(is_used_once)', -2.0, a), -1.0), ('flrp', -1.0, 1.0, ('fneg', a)), '!options->lower_flrp32'),
@@ -3726,6 +3706,10 @@ late_optimizations.extend([
     (('~ffma@32', a, 2.0, ('fneg', ('fmul', a, a))), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
     (('~ffma@32', a, 2.0, ('fmul', ('fneg', a), a)), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
     (('~ffma@32', a, ('fneg', a), ('fmul', 2.0, a)), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
+    (('~fmad@32', ('fadd', b, ('fneg', a)), a, a), ('flrp', a, b, a), '!options->lower_flrp32'),
+    (('~fmad@32', a, 2.0, ('fneg', ('fmul', a, a))), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
+    (('~fmad@32', a, 2.0, ('fmul', ('fneg', a), a)), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
+    (('~fmad@32', a, ('fneg', a), ('fmul', 2.0, a)), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
     (('~fmul@32', a, ('fadd', 2.0, ('fneg', a))), ('flrp', a, 1.0, a), '!options->lower_flrp32'),
 
     (('fmin', ('fadd(is_used_once)', '#c', a), ('fadd(is_used_once)', '#c', b)), ('fadd', c, ('fmin', a, b)), 'true', TestStatus.XFAIL),
@@ -3733,62 +3717,47 @@ late_optimizations.extend([
 
     (('bcsel@32', ('feq', ('fsqrt', 'a(is_a_number_not_negative)'), 0.0), intBitsToFloat(0x7f7fffff), ('frsq', a)),
      ('fmin', ('frsq', a), intBitsToFloat(0x7f7fffff))),
+])
 
-    (('~fadd',
-      ('ffma(is_used_once)', a, b,
-       ('ffma(is_used_once)', c, d,
-        ('ffma', e, 'f',
-         ('fmul(is_used_once)', 'g(is_not_const_and_not_fsign)', 'h(is_not_const_and_not_fsign)')))),
-      'i(is_not_const)'),
-     ('ffma', a, b, ('ffma', c, d, ('ffma', e, 'f', ('ffma', 'g', 'h', 'i')))),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+# Things that look like DPH in the source shader may get expanded to
+# something that looks like dot(v1.xyz, v2.xyz) + v1.w by the time it gets
+# to NIR.  After FFMA is generated, this can look like:
+#
+#    fadd(ffma(v1.z, v2.z, ffma(v1.y, v2.y, fmul(v1.x, v2.x))), v1.w)
+#
+# Reassociate the last addition into the first multiplication.
+#
+# Some shaders do not use 'invariant' in vertex and (possibly) geometry
+# shader stages on some outputs that are intended to be invariant.  For
+# various reasons, this optimization may not be fully applied in all
+# shaders used for different rendering passes of the same geometry.  This
+# can result in Z-fighting artifacts (at best).  For now, disable this
+# optimization in these stages.  See bugzilla #111490.  In tessellation
+# stages applications seem to use 'precise' when necessary, so allow the
+# optimization in those stages.
+for fmad in ['ffma', 'fmad']:
+    late_optimizations.extend([
+        (('~fadd', (f'{fmad}(is_used_once)', a, b, (f'{fmad}(is_used_once)', c, d, (fmad, e, 'f', ('fmul(is_used_once)', 'g(is_not_const_and_not_fsign)', 'h(is_not_const_and_not_fsign)')))), 'i(is_not_const)'),
+         (fmad, a, b, (fmad, c, d, (fmad, e, 'f', (fmad, 'g', 'h', 'i')))), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+        (('~fadd', (f'{fmad}(is_used_once)', a, b, (fmad, c, d, ('fmul(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)'))), 'g(is_not_const)'),
+         (fmad, a, b, (fmad, c, d, (fmad, e, 'f', 'g'))), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+        (('~fadd', (f'{fmad}(is_used_once)', a, b, ('fmul(is_used_once)', 'c(is_not_const_and_not_fsign)', 'd(is_not_const_and_not_fsign)') ), 'e(is_not_const)'),
+         (fmad, a, b, (fmad, c, d, e)), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+        (('~fadd', ('fneg', (f'{fmad}(is_used_once)', a, b, (fmad, c, d, ('fmul(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)')))), 'g(is_not_const)'),
+         (fmad, ('fneg', a), b, (fmad, ('fneg', c), d, (fmad, ('fneg', e), 'f', 'g'))), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+    ])
 
-    (('~fadd',
-      ('ffma(is_used_once)', a, b,
-       ('ffma', c, d,
-        ('fmul(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)'))),
-      'g(is_not_const)'),
-     ('ffma', a, b, ('ffma', c, d, ('ffma', e, 'f', 'g'))),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+for fmadz in ['ffmaz', 'fmadz']:
+    late_optimizations.extend([
+        (('~fadd', (f'{fmadz}(is_used_once)', a, b, (fmadz, c, d, ('fmulz(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)'))), 'g(is_not_const)'),
+         (fmadz, a, b, (fmadz, c, d, (fmadz, e, 'f', 'g'))), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+        (('~fadd', (f'{fmadz}(is_used_once)', a, b, ('fmulz(is_used_once)', 'c(is_not_const_and_not_fsign)', 'd(is_not_const_and_not_fsign)') ), 'e(is_not_const)'),
+         (fmadz, a, b, (fmadz, c, d, e)), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+        (('~fadd', ('fneg', (f'{fmadz}(is_used_once)', a, b, (fmadz, c, d, ('fmulz(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)')))), 'g(is_not_const)'),
+         (fmadz, ('fneg', a), b, (fmadz, ('fneg', c), d, (fmadz, ('fneg', e), 'f', 'g'))), '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
+    ])
 
-    (('~fadd',
-      ('ffma(is_used_once)', a, b,
-       ('fmul(is_used_once)', 'c(is_not_const_and_not_fsign)', 'd(is_not_const_and_not_fsign)')),
-      'e(is_not_const)'),
-     ('ffma', a, b, ('ffma', c, d, e)),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
-
-    (('~fadd',
-      ('fneg', ('ffma(is_used_once)', a, b,
-               ('ffma', c, d,
-                ('fmul(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)')))),
-      'g(is_not_const)'),
-     ('ffma', ('fneg', a), b, ('ffma', ('fneg', c), d, ('ffma', ('fneg', e), 'f', 'g'))),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
-
-    (('~fadd',
-      ('ffmaz(is_used_once)', a, b,
-       ('ffmaz', c, d,
-        ('fmulz(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)'))),
-      'g(is_not_const)'),
-     ('ffmaz', a, b, ('ffmaz', c, d, ('ffmaz', e, 'f', 'g'))),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
-
-    (('~fadd',
-      ('ffmaz(is_used_once)', a, b,
-       ('fmulz(is_used_once)', 'c(is_not_const_and_not_fsign)', 'd(is_not_const_and_not_fsign)')),
-      'e(is_not_const)'),
-     ('ffmaz', a, b, ('ffmaz', c, d, e)),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
-
-    (('~fadd',
-      ('fneg', ('ffmaz(is_used_once)', a, b,
-               ('ffmaz', c, d,
-                ('fmulz(is_used_once)', 'e(is_not_const_and_not_fsign)', 'f(is_not_const_and_not_fsign)')))),
-      'g(is_not_const)'),
-     ('ffmaz', ('fneg', a), b, ('ffmaz', ('fneg', c), d, ('ffmaz', ('fneg', e), 'f', 'g'))),
-     '(info->stage != MESA_SHADER_VERTEX && info->stage != MESA_SHADER_GEOMETRY) && !options->intel_vec4'),
-
+late_optimizations.extend([
     (('fmul(contract)', a, ('ldexp(is_used_once)', 1.0, b)), ('ldexp', a, b), 'options->has_ldexp'),
     (('frcp(contract,ninf)', ('ldexp', 1.0, b)), ('ldexp', 1.0, ('ineg', b)), 'options->has_ldexp'),
 


### PR DESCRIPTION
### Motivation

- Introduce support for weak/flexible fused multiply-add forms and make fusion behavior configurable per floating-point size to match backend capabilities and options.
- Replace ad-hoc, duplicated FFMA/FFMAZ rules with option-driven generation to correctly prefer `ffma` vs `fmad` and handle `fmulz` variants.
- Ensure lowered helpers (like the sin/cos approximation) use the weak ffma form so it can be lowered or fused according to target options.

### Description

- Changed `lowered_sincos` to emit `ffma_weak` instead of a hard `ffma` so targets can opt to keep or split the operation by configuration. 
- Added per-size (`16`, `32`, `64`) float mul-add option parsing and rule generation using `options->float_mul_add{sz}` flags for `has_ffma`, `has_fmad`, `prefers_split`, and `keep_weak_ffma`, and wired those into the `optimizations` list to pick the right replacement. 
- Added canonicalization rules for `fmad`/`fmadz` to `fadd(fmul(), ...)` and generated fusion rules in `late_optimizations` for both `ffma`/`ffmaz` and `fmad`/`fmadz` cases, including handling of `fmulz` and `fabs`/`fneg` operand patterns and an `avoid_ternary_with_fabs` option.
- Refactored many explicit, duplicated FFMA/FFMAZ fusion patterns into loops that generate the appropriate patterns for sizes and variants, and added explanatory comments and stage-restrictions around aggressive reassociation of nested mul-adds.

### Testing

- Ran the repository's Python linter and static checks successfully. 
- Executed the existing NIR optimizer unit tests and the `vega-experiments` test subset; all automated tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cde230650832aaf16296bd929ef85)